### PR TITLE
Makes the SipCreatorEndPoint work with the fixed Play version. Closes #59

### DIFF
--- a/app/controllers/SipCreatorEndPoint.scala
+++ b/app/controllers/SipCreatorEndPoint.scala
@@ -131,7 +131,9 @@ object SipCreatorEndPoint extends Controller with AdditionalActions {
   }
 
 
-  def acceptFile(spec: String, fileName: String): Result = {
+  def acceptFile: Result = {
+    val spec = params.get("spec")
+    val fileName = params.get("fileName")
     log.info(String.format("Accepting file %s for DataSet %s", fileName, spec))
     val dataSet = DataSet.findBySpec(spec).getOrElse(return TextError("Unknown spec %s".format(spec)))
 


### PR DESCRIPTION
This fix retrieves parameters from the request rather than using Play's invoker mechanism to bind them against the method.
With the just-released fix for the request body processing, this now fixes this issue.
