### PR TITLE
Multi-sized thumbnails

### DIFF
--- a/app/controllers/FileStore.scala
+++ b/app/controllers/FileStore.scala
@@ -9,6 +9,7 @@ import com.mongodb.casbah.gridfs.{GridFSDBFile, GridFS}
 import com.mongodb.casbah.commons.MongoDBObject
 import com.mongodb.casbah.MongoConnection
 import com.mongodb.casbah.commons.conversions.scala.RegisterJodaTimeConversionHelpers
+import user.FileUpload
 
 /**
  * Common controller for handling files, no matter from where.
@@ -25,14 +26,14 @@ object FileStore extends DelvingController {
   val emptyThumbnail = "/public/images/dummy-object.png"
   val emptyThumbnailFile = new File(play.Play.applicationPath + emptyThumbnail)
 
-  val THUMBNAIL_WIDTH = 220
+  val DEFAULT_THUMBNAIL_WIDTH = 220
 
   val THUMBNAIL_WIDTH_FIELD = "thumbnail_width"
 
   // ~~ images uploaded directly via culturehub
   val UPLOAD_UID_FIELD = "uid" // temporary UID given to files that are not yet attached to an object after upload
   val OBJECT_POINTER_FIELD = "object_id" // pointer to the owning object, for cleanup
-  val FILE_POINTER_FIELD = "original_file" // pointer from a thumbnail to its parent
+  val FILE_POINTER_FIELD = "original_file" // pointer from a thumbnail to its parent file
   val IMAGE_OBJECT_POINTER_FIELD = "image_object_id" // pointer from an chosen image to its object, useful to lookup an image by object ID
   val THUMBNAIL_OBJECT_POINTER_FIELD = "thumbnail_object_id" // pointer from a chosen thumbnail to its object, useful to lookup a thumbnail by object ID
 
@@ -52,19 +53,27 @@ object FileStore extends DelvingController {
     new RenderBinary(file.inputStream, file.filename, file.length, file.contentType, false)
   }
 
-  def displayThumbnail(id: String, width: Int): Result = getImage(id, true, width)
+  def displayThumbnail(id: String, width: String = ""): Result = {
+    val thumbnailWidth = if (FileUpload.thumbnailSizes.contains(width)) {
+      FileUpload.thumbnailSizes(width)
+    } else {
+      try {
+        Integer.parseInt(width)
+      } catch {
+        case _ => DEFAULT_THUMBNAIL_WIDTH
+      }
+    }
+    renderImage(id, true, thumbnailWidth)
+  }
 
-  def displayImage(id: String): Result = getImage(id, false)
+  def displayImage(id: String): Result = renderImage(id, false)
 
-  @Util def getImage(id: String, thumbnail: Boolean, thumbnailWidth: Int = THUMBNAIL_WIDTH): Result = {
+  @Util def renderImage(id: String, thumbnail: Boolean, thumbnailWidth: Int = DEFAULT_THUMBNAIL_WIDTH): Result = {
 
     val (field, oid) = if (ObjectId.isValid(id)) {
-      (if (thumbnail) {
-        THUMBNAIL_OBJECT_POINTER_FIELD
-      } else {
-        IMAGE_OBJECT_POINTER_FIELD
-      }, new ObjectId(id))
+      (if (thumbnail) THUMBNAIL_OBJECT_POINTER_FIELD else IMAGE_OBJECT_POINTER_FIELD, new ObjectId(id))
     } else {
+      // string identifier - for e.g. ingested images
       (IMAGE_ID_FIELD, id)
     }
 

--- a/app/controllers/user/DObjects.scala
+++ b/app/controllers/user/DObjects.scala
@@ -54,8 +54,9 @@ object DObjects extends DelvingController with UserAuthentication with Secure {
 
     val files = user.FileUpload.fetchFilesForUID(uid)
 
+    /** finds thumbnail candidate for an object, "activate" thumbnails (for easy lookup) and returns the OID of the thumbnail candidate image file **/
     def activateThumbnail(objectId: ObjectId) = findThumbnailCandidate(files) match {
-        case Some(f) => FileUpload.activateThumbnail(f.id, objectId)
+        case Some(f) => FileUpload.activateThumbnails(f.id, objectId); Some(f.id)
         case None => None
     }
 

--- a/app/models/DObject.scala
+++ b/app/models/DObject.scala
@@ -36,7 +36,7 @@ object DObject extends SalatDAO[DObject, ObjectId](objectsCollection) with Commo
   def findAllUnassignedForUser(id: ObjectId) = find(MongoDBObject("user_id" -> id, "collections" -> MongoDBObject("$size" -> 0)))
 
   def updateThumbnail(id: ObjectId, thumbnail_id: ObjectId) {
-    update(MongoDBObject("_id" -> id), MongoDBObject("$set" -> MongoDBObject("thumbnail_id" -> thumbnail_id)) , false, false)
+    update(MongoDBObject("_id" -> id), MongoDBObject("$set" -> MongoDBObject("thumbnail_file_id" -> thumbnail_id)) , false, false)
   }
 
   def fetchName(id: String): String = findById(id).get.name

--- a/test/FileStoreSpec.scala
+++ b/test/FileStoreSpec.scala
@@ -55,8 +55,8 @@ class FileStoreSpec extends UnitFlatSpec with ShouldMatchers with TestDataGeneri
   it should "mark an active thumbnail and an active image given a file pointer and object ID" in {
     FileUpload.activateThumbnail(uploaded_id, TEST_OID)
 
-    val image = FileStore.getImage(TEST_OID.toString, false)
-    val thumbnail = FileStore.getImage(TEST_OID.toString, true)
+    val image = FileStore.renderImage(TEST_OID.toString, false)
+    val thumbnail = FileStore.renderImage(TEST_OID.toString, true)
 
     image.getClass should equal (classOf[RenderBinary])
     thumbnail.getClass should equal (classOf[RenderBinary])


### PR DESCRIPTION
On image upload, create a batch of thumbnails that can then be retrieved by either width in pixels or shorthand (tiny, small, ...)
