### PR TITLE
API for fetching theme properties stored in application.conf

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -12,9 +12,9 @@ object Application extends DelvingController {
 
   def index: Result = {
 
-    val recentCollections: List[ShortCollection] = UserCollection.findRecent(3).toList
-    val recentStories: List[ShortStory] = Story.findRecent(3).toList
-    val recentObjects: List[ListItem] = DObject.findRecent(12).toList
+    val recentCollections: List[ShortCollection] = UserCollection.findRecent(viewUtils.themeProperty("recentCollectionsCount", classOf[Int])).toList
+    val recentStories: List[ShortStory] = Story.findRecent(viewUtils.themeProperty("recentStoriesCount", classOf[Int])).toList
+    val recentObjects: List[ListItem] = DObject.findRecent(viewUtils.themeProperty("recentObjectsCount", classOf[Int])).toList
 
     Template('recentCollections -> recentCollections, 'recentStories -> recentStories, 'recentObjects -> recentObjects)
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -257,3 +257,14 @@ services.pmh.harvestStepCleanupDelay = 15000
 # The name of the OAI-PMH  reposistory database in mongodb. This db is created when the application starts up the first time.
 
 services.mongo.dbName = MetaRepo
+
+
+###############################################
+#                                             #
+#       Themes settings, temporary location   #
+#                                             #
+###############################################
+
+themes.default.recentCollectionsCount=3
+themes.default.recentStoriesCount=3
+themes.default.recentObjectsCount=12


### PR DESCRIPTION
API for fetching theme properties stored in application.conf. This is first rudimentary implementation, the only data-types that are supported are (single) strings and ints.

Use this in `DelvingController`-s like this:

```
 viewUtils.themeProperty("recentStoriesCount", classOf[Int])
```

and in the view like this:

```
${viewUtils.themeProperty("myProperty")}
```

Properties should be defined in `conf/application.conf` and need to have a default value
