### PR TITLE
Mongodb is now able to start-up in test, single target and ReplicaSet mod

### DIFF
--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -11,7 +11,7 @@ package object salatContext {
 
   val connectionName = if(Play.configuration != null) Play.configuration.getProperty("db.cultureHub.name") else if(Play.mode == Play.Mode.DEV) "culturehub" else null
 
-  val connection: MongoDB  =  if (Play.configuration.getProperty("mongo.test.context").toBoolean ) {
+  val connection: MongoDB  =  if (Play.configuration.getProperty("mongo.test.context").toBoolean || Play.mode == Play.Mode.DEV) {
     Logger.info("Starting Mongo in Test Mode connecting to localhost:27017")
     MongoConnection()(connectionName)
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -256,7 +256,7 @@ services.mongo.dbName = MetaRepo
 #                                             #
 ###############################################
 
-mongo.test.context = false
+mongo.test.context = true
 mongo.server1.host = 127.0.0.1
 mongo.server1.port = 27017
 mongo.server2.host = 127.0.0.1
@@ -264,7 +264,13 @@ mongo.server2.port = 27018
 mongo.server3.host = 127.0.0.1
 mongo.server3.port = 27019
 
-
+%prod.mongo.test.context = false
+%prod.mongo.server1.host = mongo1
+%prod.mongo.server1.port = 27017
+%prod.mongo.server2.host = mongo2
+%prod.mongo.server2.port = 27017
+%prod.mongo.server3.host = mongo1
+%prod.mongo.server3.port = 27019
 
 
 ###############################################

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -250,6 +250,22 @@ services.pmh.harvestStepCleanupDelay = 15000
 
 services.mongo.dbName = MetaRepo
 
+###############################################
+#                                             #
+#      Mongo Settings                         #
+#                                             #
+###############################################
+
+mongo.test.context = false
+mongo.server1.host = 127.0.0.1
+mongo.server1.port = 27017
+mongo.server2.host = 127.0.0.1
+mongo.server2.port = 27018
+mongo.server3.host = 127.0.0.1
+mongo.server3.port = 27019
+
+
+
 
 ###############################################
 #                                             #


### PR DESCRIPTION
Mongodb is now able to start-up in test, single target and ReplicaSet mode. 

With the current configuration in `application.conf` nothing will change from the current setup. If you want to connect to an remote host, you have to configure server1 host/port with the ip address.  
