### PR TITLE
TinyMCE fix

### DIFF
--- a/app/views/user/Stories/story.html
+++ b/app/views/user/Stories/story.html
@@ -198,6 +198,7 @@
                 $("#form-add-page").show("slow");
             },
             editPage: function(page) {
+                storyModel.currentPage.lock(true);
                 storyModel.currentPage.isNew(false);
                 storyModel.currentPage.pageRef(page),
                 storyModel.currentPage.title(page.title());

--- a/public/themes/common/javascripts/culturehub.js
+++ b/public/themes/common/javascripts/culturehub.js
@@ -342,7 +342,10 @@ ko.bindingHandlers.tinymce = {
         options.setup = function (ed) {
             ed.onChange.add(function (ed, l) {
                 if (ko.isWriteableObservable(modelValue)) {
+                    $(element).data("writeLock")
+                    $(element).data("writeLock", true);
                     modelValue(l.content);
+                    $(element).data("writeLock", false);
                 }
             });
         };
@@ -367,7 +370,9 @@ ko.bindingHandlers.tinymce = {
         //handle programmatic updates to the observable
         var value = ko.utils.unwrapObservable(valueAccessor());
         var ed = tinyMCE.get(element.id.replace(/_parent$/, ""));
-        if (typeof ed !== 'undefined') ed.setContent(value);
+        if(!$(element).data("writeLock")) {
+            if (typeof ed !== 'undefined') ed.setContent(value);
+        }
     }
 };
 


### PR DESCRIPTION
Not updating the textArea when the viewModel change comes from us typing (via an element-based lock). Fixes #266
