### PR TITLE
Generifying link creation / deletion

### DIFF
--- a/app/models/Link.scala
+++ b/app/models/Link.scala
@@ -82,10 +82,10 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
         case None =>
           
           // sanity check on the embedded stuff
-          if(embedFrom != None && ((link.from.hubAlternativeId == None || link.from.hubCollection == None) && (link.from.hubType == None || link.from.id == None))) {
+          if(embedFrom != None && ((link.from.hubAlternativeId == None || link.from.hubCollection == None || link.from.hubType == None) && (link.from.hubType == None || link.from.id == None))) {
             throw new ProgrammerException("You can't create a link with an embedFrom if the linkReference has no hubType and id OR hubCollection and hubAlternativeId!")
           }
-          if(embedTo != None && ((link.to.hubAlternativeId == None || link.to.hubCollection == None) && (link.to.hubType == None || link.to.id == None))) {
+          if(embedTo != None && ((link.to.hubAlternativeId == None || link.to.hubCollection == None || link.to.hubType == None) && (link.to.hubType == None || link.to.id == None))) {
             throw new ProgrammerException("You can't create a link with an embedTo if the linkReference has no hubType and id OR hubCollection and hubAlternativeId!")
           }
           

--- a/app/models/Link.scala
+++ b/app/models/Link.scala
@@ -1,23 +1,29 @@
 package models
 
+import _root_.util.Constants._
+import _root_.util.ProgrammerException
 import org.bson.types.ObjectId
 import com.novus.salat.dao.SalatDAO
 import salatContext._
 import java.util.Date
 import com.mongodb.casbah.Imports._
+import com.novus.salat._
+import play.Logger
 
 case class Link(_id: ObjectId = new ObjectId,
-                 userName: String, // user who created the label in the first place
-                 linkType: String, // internal type of the link: freeText, place
-                 from: LinkReference,
-                 to: LinkReference,
-                 value: Map[String, String]) {
+                userName: String, // user who created the label in the first place
+                linkType: String, // internal type of the link: freeText, place
+                from: LinkReference,
+                to: LinkReference,
+                value: Map[String, String]) {
 
 }
 
 object Link extends SalatDAO[Link, ObjectId](linksCollection) {
 
-  val LABEL = "label" // the label / name of a link
+  val LABEL = "label"
+
+  // the label / name of a link
 
   object LinkType {
     val FREETEXT = "freeText"
@@ -25,9 +31,24 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
     val PARTOF = "partOf"
   }
 
-  def create(linkType: String, userName: String, value: Map[String, String], from: LinkReference, to: LinkReference, allowDuplicates: Boolean = false): (Option[ObjectId], Link, Boolean) = {
+  /**
+   * Creates a link
+   *
+   * @param linkType        type of the link, see LinkType object
+   * @param userName        user name of the creator
+   * @param value           value of the link
+   * @param from            from where this link comes
+   * @param to              to where this link goes
+   * @param embedFrom       optional embedded link to be written in the source object
+   * @param embedTo         optional embedded link to be written in the target object
+   * @param allowDuplicates whether or not this link can exist more than one time (false by default)
+   */
+  def create(linkType: String, userName: String, value: Map[String, String], from: LinkReference, to: LinkReference,
+             embedFrom: Option[EmbeddedLinkWriter] = None, embedTo: Option[EmbeddedLinkWriter] = None,
+             allowDuplicates: Boolean = false): (Option[ObjectId], Link, Boolean) = {
+
     val link = Link(userName = userName, linkType = linkType, value = value, from = from, to = to)
-    if(allowDuplicates) {
+    if (allowDuplicates) {
       (Link.insert(link), link, true)
     } else {
 
@@ -40,7 +61,7 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
           case None =>
         }
         ref.hubType match {
-          case Some(ht) => builder+= (refName + ".hubType" -> ht)
+          case Some(ht) => builder += (refName + ".hubType" -> ht)
           case None =>
         }
         ref.uri match {
@@ -58,9 +79,79 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
 
       Link.findOne(q) match {
         case Some(l) => (Some(l._id), l, true)
-        case None => (Link.insert(link), link, false)
+        case None =>
+          
+          // sanity check on the embedded stuff
+          if(embedFrom != None && ((link.from.hubAlternativeId == None || link.from.hubCollection == None) && (link.from.hubType == None || link.from.id == None))) {
+            throw new ProgrammerException("You can't create a link with an embedFrom if the linkReference has no hubType and id OR hubCollection and hubAlternativeId!")
+          }
+          if(embedTo != None && ((link.to.hubAlternativeId == None || link.to.hubCollection == None) && (link.to.hubType == None || link.to.id == None))) {
+            throw new ProgrammerException("You can't create a link with an embedTo if the linkReference has no hubType and id OR hubCollection and hubAlternativeId!")
+          }
+          
+          val inserted = Link.insert(link)
+
+          inserted match {
+            case Some(l) =>
+              val e = EmbeddedLink(userName = link.userName, linkType = link.linkType, link = l)
+              embedFrom match {
+                case Some(from) => from.write(e)
+                case None => // nope
+              }
+              embedTo match {
+                case Some(to) => to.write(e)
+                case None => // nope
+              }
+            case None =>
+              // well this should never be returned, Salat will blow up first
+              return (null, null, false)
+          }
+          (inserted, link, false)
       }
     }
+  }
+  
+  def removeById(linkId: ObjectId) {
+    Link.findOneByID(linkId) match {
+      case Some(link) => removeLink(link)
+      case None => // it's not there
+    }
+  }
+
+  def removeLink(link: Link) {
+    
+    def removeEmbedded(link: ObjectId, hubType: String, id: Option[ObjectId], hubCollection: Option[String], hubAlternativeId: Option[String]) {
+      val collection: Option[MongoCollection] = Option(hubType match {
+        case OBJECT => objectsCollection
+        case USERCOLLECTION => userCollectionsCollection
+        case STORY => userStoriesCollection
+        case USER => userCollection
+        case _ => null
+      })
+      val pull = $pull ("links" -> MongoDBObject("link" -> link))
+      collection match {
+        case Some(c) =>
+          c.update(MongoDBObject("_id" -> id.get), pull)
+        case None =>
+          if(hubType == MDR && hubCollection.isDefined && hubAlternativeId.isDefined) {
+            connection(hubCollection.get).update(MongoDBObject(MDR_ID -> hubAlternativeId.get), pull)
+          } else {
+            Logger.warn("Could not delete embedded Link %s %s %s", hubType, id, hubCollection)
+          }
+      }
+
+    }
+    
+    // remove embedded guys
+    if((link.from.hubType != None && link.from.id != None) || (link.from.hubCollection != None && link.from.hubAlternativeId != None && link.from.hubType != None)) {
+      removeEmbedded(link._id, link.from.hubType.get, link.from.id, link.from.hubCollection, link.from.hubAlternativeId)
+    }
+    if((link.to.hubType != None && link.to.id != None) || (link.to.hubCollection != None && link.to.hubAlternativeId != None && link.to.hubType != None)) {
+      removeEmbedded(link._id, link.to.hubType.get, link.to.id, link.to.hubCollection, link.to.hubAlternativeId)
+    }
+
+    Link.remove(link)
+
   }
 
   def findTo(toUri: String, linkType: String) = Link.find(MongoDBObject("linkType" -> linkType, "to.uri" -> toUri))
@@ -71,12 +162,41 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
  * An arrow in a link. This is flexible: if we have a hubType we can lookup by mongo id, or else we have a uri.
  */
 case class LinkReference(id: Option[ObjectId] = None, // mongo id for hub-based reference
-                         uri: Option[String] = None, // URI
                          hubType: Option[String] = None, // internal CH type of the reference (DObject, ...)
+                         hubCollection: Option[String] = None, // name of the mongodb collection this reference lives in, if it can't be infered from the hubType
+                         hubAlternativeId: Option[String] = None, // alternative ID value in case ID does not apply
+                         uri: Option[String] = None, // URI
                          refType: Option[String] = None) // external type of the reference
 
 
 /**
  * A denormalized bit of a link that lives in a linked object. Makes it easy to do lookups.
  */
-case class EmbeddedLink(TS: Date = new Date(), userName: String, linkType: String, link: ObjectId, value: Map[String,  String])
+case class EmbeddedLink(TS: Date = new Date(), userName: String, linkType: String, link: ObjectId, value: Map[String, String] = Map.empty[String, String])
+
+/**
+ * This guy knows how to write an embedded link and give it a value
+ */
+case class EmbeddedLinkWriter(value: Map[String, String], collection: MongoCollection, id: Option[ObjectId] = None, alternativeId: Option[(String, String)] = None) {
+
+  def write(embeddedLink: EmbeddedLink): Either[String, String] = {
+    if (id == None && alternativeId == None) return Left("No ID provided for writing embedded link")
+    val serEmb = grater[EmbeddedLink].asDBObject(embeddedLink.copy(value = value))
+    id match {
+      case Some(objectId) =>
+        collection.update(MongoDBObject("_id" -> objectId), $push("links" -> serEmb))
+        // TODO check write result
+        Right("ok")
+      case None =>
+        alternativeId match {
+          case Some(tuple) =>
+            val field = tuple._1
+            val value = tuple._2
+            collection.update(MongoDBObject(field -> value), $push("links" -> serEmb))
+            // TODO check write result
+            Right("ok")
+          case None => Left("impossible!")
+        }
+    }
+  }
+}

--- a/app/util/Constants.scala
+++ b/app/util/Constants.scala
@@ -41,8 +41,11 @@ object Constants {
   // ~~~ link value fields
   val USERCOLLECTION_ID = "userCollectionId" // mongo ID of a collection
 
-
   // ~~~~~ Solr Constants
   val MORE_LIKE_THIS = "moreLikeThis"
+
+  // ~~~ special cases
+  val MDR_ID: String = "localRecordKey"
+
 
 }

--- a/app/views/tags/thingToolbar.html
+++ b/app/views/tags/thingToolbar.html
@@ -98,9 +98,9 @@
       searchingText: "&{'labels.tokenSearching'}",
       allowCreation: true,
       createTokenText: "(&{'labels.createLabel'})"
-    }, '/${_authUser}/${_type}/${_id}/link/freeText', function(item) {
+    }, '/${_authUser}/link/freeText/${_type}/${_id}', function(item) {
       return {label: item.name}
-    }, '/${_authUser}/${_type}/${_id}/link/freeText/', function(item) {
+    }, '/${_authUser}/link/freeText/', function(item) {
       $('#labels ul').append('<li id="' + item.id + '">' + item.name + '</li>');
     }, function(item) {
       $('li[id=' + item.id + ']').remove();
@@ -114,7 +114,9 @@
         return "<li><div style='display: inline-block;'><div class='place_name'>" + item.name + "</div><div class='country_name' style='font-style: italic;'>" + item.countryName + "</div></div></li>"
       },
       allowCreation: false
-    }, '/${_authUser}/${_type}/${_id}/link/place', function(item) {
+    }, function(item) {
+        return '/${_authUser}/${_type}/${_id}/link/place/place/' + item.geonameID;
+    }, function(item) {
       item.label = item.name;
       return item;
     }, '/${_authUser}/${_type}/${_id}/link/place/', function(it) {

--- a/conf/routes
+++ b/conf/routes
@@ -88,12 +88,14 @@ GET         /{user}/?                                                        Pro
 
 GET         /{user}/label/search                                             Links.listFreeTextAsTokens
 
+POST        /{user}/link/{linkType}/{toType}/{toId}                          user.Links.add(fromType:'user')
+DELETE      /{user}/link/{linkType}/{link}                                   user.Links.removeById(fromType:'user')
+
 GET         /{user}/object                                                   DObjects.list
 GET         /{user}/object/add                                               user.DObjects.dobject
 GET         /{user}/object/{id}/update                                       user.DObjects.dobject
-POST        /{user}/object/{id}/link/{linkType}                              user.Links.add(fromType:'object')
-POST        /{user}/object/{id}/link/{linkType}/{toType}/{toId}              user.Links.add(fromType:'object')
-DELETE      /{user}/object/{id}/link/{linkType}/{link}                       user.Links.removeById(fromType:'object')
+POST        /{user}/object/{fromId}/link/{linkType}/{toType}/{toId}          user.Links.add(fromType:'object')
+DELETE      /{user}/object/{fromId}/link/{linkType}/{link}                   user.Links.removeById(fromType:'object')
 POST        /{user}/object/submit                                            user.DObjects.objectSubmit
 DELETE      /{user}/object/{id}/remove                                       user.DObjects.remove
 
@@ -110,8 +112,8 @@ GET         /{user}/collection/{id}/objects                                  Col
 GET         /{user}/collection/{collectionId}/object/{id}                    DObjects.dobject
 GET         /{user}/collection/add                                           user.Collections.collection
 GET         /{user}/collection/{id}/update                                   user.Collections.collection
-POST        /{user}/collection/{id}/link/{linkType}                          user.Links.add(fromType:'collection')
-DELETE      /{user}/collection/{id}/link/{linkType}/{link}                   user.Links.removeById(fromType:'collection')
+POST        /{user}/collection/{fromId}/link/{linkType}/{toType}/{toId}      user.Links.add(fromType:'collection')
+DELETE      /{user}/collection/{fromId}/link/{linkType}/{link}               user.Links.removeById(fromType:'collection')
 POST        /{user}/collection/submit                                        user.Collections.collectionSubmit
 DELETE      /{user}/collection/{id}/remove                                   user.Collections.remove
 GET         /{user}/collection/{id}                                          Collections.collection
@@ -119,8 +121,8 @@ GET         /{user}/collection/{id}                                          Col
 GET         /{user}/story                                                    Stories.list
 GET         /{user}/story/add                                                user.Stories.story
 GET         /{user}/story/{id}/update                                        user.Stories.story
-POST        /{user}/story/{id}/link/{linkType}                               user.Links.add(fromType:'story')
-DELETE      /{user}/story/{id}/link/{linkType}/{link}                        user.Links.removeById(fromType:'story')
+POST        /{user}/story/{fromId}/link/{linkType}/{toType}/{toId}           user.Links.add(fromType:'story')
+DELETE      /{user}/story/{fromId}/link/{linkType}/{link}                    user.Links.removeById(fromType:'story')
 POST        /{user}/story/submit                                             user.Stories.storySubmit
 DELETE      /{user}/story/{id}/remove                                        user.Stories.remove
 GET         /{user}/story/{id}                                               Stories.story

--- a/public/themes/common/javascripts/culturehub.js
+++ b/public/themes/common/javascripts/culturehub.js
@@ -34,7 +34,7 @@ function tokenInput(id, searchUrl, prePopulate, params, addUrl, addData, deleteU
         $.ajax({
           type: 'POST',
           data: typeof addData === 'function' ? addData.call(this, item) : addData,
-          url: addUrl,
+          url: typeof addUrl === 'function' ? addUrl.call(this, item) : addUrl,
           success: function(data) {
             if(item.wasCreated) {
               item.id = data.id;

--- a/test/LabelsSpec.scala
+++ b/test/LabelsSpec.scala
@@ -20,7 +20,7 @@ class LabelsSpec extends UnitFlatSpec with ShouldMatchers with TestDataGeneric {
 
     val req = getAuthenticated()
     req.method = "POST"
-    val response: Response = FunctionalTest.POST(req, "/bob/object/%s/link/freeText".format(dobject._id.toString), Map("label" -> "toto"), Map.empty[String, File])
+    val response: Response = FunctionalTest.POST(req, "/bob/link/freeText/object/%s".format(dobject._id.toString), Map("label" -> "toto"), Map.empty[String, File])
 
     response.status should be (200)
 
@@ -43,7 +43,7 @@ class LabelsSpec extends UnitFlatSpec with ShouldMatchers with TestDataGeneric {
 
     val req = getAuthenticated()
     req.method = "POST"
-    val response: Response = FunctionalTest.POST(req, "/bob/object/%s/link/freeText".format(dobject._id.toString), Map("label" -> "toto"), Map.empty[String, File])
+    val response: Response = FunctionalTest.POST(req, "/bob/link/freeText/object/%s".format(dobject._id.toString), Map("label" -> "toto"), Map.empty[String, File])
 
     response.status should be (200)
 
@@ -75,7 +75,7 @@ class LabelsSpec extends UnitFlatSpec with ShouldMatchers with TestDataGeneric {
 
     val req = getAuthenticated()
     req.method = "POST"
-    val response: Response = FunctionalTest.POST(req, "/bob/object/%s/link/place".format(dobject._id.toString), Map("label" -> "Earth", "geonameID" -> "42"), Map.empty[String, File])
+    val response: Response = FunctionalTest.POST(req, "/bob/object/%s/link/place/place/42".format(dobject._id.toString), Map("label" -> "Earth", "geonameID" -> "42"), Map.empty[String, File])
 
     response.status should be (200)
     Link.count(MongoDBObject("value.label" -> "Earth", "value.geonameID" -> "42", "linkType" -> Link.LinkType.PLACE)) should equal (1)


### PR DESCRIPTION
Rewrite of the link system. Links can now be created and at creation time one can specify to add embedded links in from and/or to. A precondition for creating embedded links is to provide either one of the following:
- hubType and id
- hubType, hubCollection and hubAlternativeId

This way the EmbeddedLinkWriter can create the embedded automatically, and things can be deleted gracefully when the master link is deleted.

All link routes now follow the general scheme

```
/from/{fromId}/link/{linkType}/{toType}/{toId}
```

We use a convenience method of Play's routing to add a static argument to infer the fromType (since that may be more complex in some cases). Basically this means we always get access to:
- fromType
- fromId
- linkType
- toType
- toId
