### PR TITLE
Mapping prefix move

### DIFF
--- a/app/components/Indexing.scala
+++ b/app/components/Indexing.scala
@@ -199,6 +199,14 @@ object Indexing extends SolrServer with controllers.ModelImplicits {
     
     if (inputDoc.containsKey(ID)) inputDoc.remove(ID)
     inputDoc.addField(ID, hubId)
+
+    val uriWithTypeSuffix = EUROPEANA_URI + "_string"
+    if (inputDoc.containsKey(uriWithTypeSuffix)) {
+      val uriValue: String = inputDoc.get(uriWithTypeSuffix).getFirstValue.toString
+      inputDoc.remove(uriWithTypeSuffix)
+      inputDoc.addField(EUROPEANA_URI, uriValue)
+    }
+
     val hasDigialObject: Boolean = inputDoc.containsKey(THUMBNAIL) && !inputDoc.get(THUMBNAIL).getValues.isEmpty
     inputDoc.addField(HAS_DIGITAL_OBJECT, hasDigialObject)
 

--- a/app/components/Indexing.scala
+++ b/app/components/Indexing.scala
@@ -102,14 +102,14 @@ object Indexing extends SolrServer with controllers.ModelImplicits {
     Right("ok")
   }
 
-  def indexOneInSolr(orgId: String, spec: String, metadataFormatForIndexing: String, mdr: MetadataRecord) = {
+  def indexOneInSolr(orgId: String, spec: String, mdr: MetadataRecord) = {
     DataSet.findBySpecAndOrgId(spec, orgId) match {
       case Some(dataSet) =>
-        val mapping = dataSet.mappings.get(metadataFormatForIndexing)
-        if (mapping == None) throw new MappingNotFoundException("Unable to find mapping for " + metadataFormatForIndexing)
+        val mapping = dataSet.mappings.get(dataSet.getIndexingMappingPrefix.getOrElse(""))
+        if (mapping == None) throw new MappingNotFoundException("Unable to find mapping for " + dataSet.getIndexingMappingPrefix.getOrElse("NONE DEFINED!"))
         val engine: MappingEngine = new MappingEngine(mapping.get.recordMapping.getOrElse(""), asJavaMap(dataSet.namespaces), play.Play.classloader.getParent, ComponentRegistry.metadataModel)
         val mapped = Option(engine.executeMapping(mdr.getXmlString()))
-        indexOne(dataSet, mdr, mapped, metadataFormatForIndexing)
+        indexOne(dataSet, mdr, mapped, dataSet.getIndexingMappingPrefix.getOrElse(""))
       case None =>
         Logger.warn("Could not index MDR")
     }

--- a/app/controllers/ModelImplicits.scala
+++ b/app/controllers/ModelImplicits.scala
@@ -36,7 +36,17 @@ trait ModelImplicits extends Internationalization {
   implicit def linkToToken(embeddedLink: EmbeddedLink): Token = Token(embeddedLink.link.toString, embeddedLink.value("label"), Some(embeddedLink.linkType), Some(embeddedLink.value))
   implicit def linkListToTokenList(l: List[EmbeddedLink]) = l.map { linkToToken(_) }
 
-  implicit def dataSetToShort(ds: DataSet) = ShortDataSet(Option(ds._id), ds.spec, ds.details.total_records, ds.state, ds.getFacts, ds.mappings.keySet.toList, ds.orgId, ds.getCreator.userName)
+  implicit def dataSetToShort(ds: DataSet) = ShortDataSet(
+    id = Option(ds._id),
+    spec = ds.spec,
+    total_records = ds.details.total_records,
+    state = ds.state,
+    facts = ds.getFacts,
+    recordDefinitions = ds.mappings.keySet.toList,
+    indexingMappingPrefix = ds.getIndexingMappingPrefix,
+    orgId = ds.orgId,
+    userName = ds.getCreator.userName)
+
   implicit def dSListToSdSList(dsl: List[DataSet]) = dsl map { ds => dataSetToShort(ds) }
 
   implicit def objectToShortObjectModel(o: DObject): ShortObjectModel = ShortObjectModel(o._id, o.url, thumbnailUrl(o.thumbnail_id), o.name, util.Constants.OBJECT)

--- a/app/controllers/ModelImplicits.scala
+++ b/app/controllers/ModelImplicits.scala
@@ -43,7 +43,7 @@ trait ModelImplicits extends Internationalization {
     state = ds.state,
     facts = ds.getFacts,
     recordDefinitions = ds.mappings.keySet.toList,
-    indexingMappingPrefix = ds.getIndexingMappingPrefix,
+    indexingMappingPrefix = ds.getIndexingMappingPrefix.getOrElse("NONE"),
     orgId = ds.orgId,
     userName = ds.getCreator.userName)
 

--- a/app/controllers/Models.scala
+++ b/app/controllers/Models.scala
@@ -28,6 +28,7 @@ case class ShortDataSet(id: Option[ObjectId] = None,
                         state: DataSetState = DataSetState.INCOMPLETE,
                         facts: Map[String, String] = Map.empty[String, String],
                         recordDefinitions: List[String] = List.empty[String],
+                        indexingMappingPrefix: String,
                         orgId: String,
                         userName: String,
                         errors: Map[String, String] = Map.empty[String, String], visibility: Int = 0)

--- a/app/controllers/Search.scala
+++ b/app/controllers/Search.scala
@@ -55,7 +55,7 @@ object Search extends DelvingController {
     val id = "%s_%s_%s".format(orgId, spec, recordId)
     val idType = DelvingIdType(id, params.all().getOrElse("idType", Array[String]("hubId")).head)
     val chQuery = SolrQueryService.createCHQuery(request, theme, false)
-    val changedQuery = chQuery.copy(solrQuery = chQuery.solrQuery.setQuery("%s:%s".format(idType.idSearchField, idType.normalisedId)))
+    val changedQuery = chQuery.copy(solrQuery = chQuery.solrQuery.setQuery("%s:\"%s\"".format(idType.idSearchField, idType.normalisedId)))
     val queryResponse = SolrQueryService.getSolrResponseFromServer(changedQuery.solrQuery, true)
     val response = CHResponse(params, theme, queryResponse, changedQuery)
 

--- a/app/controllers/Services.scala
+++ b/app/controllers/Services.scala
@@ -87,13 +87,4 @@ object Services extends DelvingController with HTTPClient {
       case None => SearchService.getApiResult(request, theme)
     }
   }
-
-  def retrieveRecord(spec: String, id: String): Result = {
-
-    // Sjoerd: this works for e.g. http://localhost:9000/services/api/Verzetsmuseum:4e8898050364481a6dbe8dc8
-    // I wrapped this into a record root element, maybe it needs to contain namespaces?
-
-    val record = DataSet.getRecord(spec + ":" + id, theme.metadataPrefix.getOrElse("icn")).getOrElse(return NotFound)
-    Xml("<record>" + record.getXmlString() + "</record>")
-  }
 }

--- a/app/controllers/admin/Themes.scala
+++ b/app/controllers/admin/Themes.scala
@@ -50,7 +50,6 @@ object Themes extends DelvingController with AdminSecure {
         cacheUrl = theme.cacheUrl,
         emailTarget = theme.emailTarget,
         homePage = theme.homePage,
-        metadataPrefix = theme.metadataPrefix,
         possibleQueryKeys = theme.localiseQueryKeys)
       )
     }
@@ -77,7 +76,7 @@ object Themes extends DelvingController with AdminSecure {
           solrSelectUrl = theme.solrSelectUrl, 
           cacheUrl = theme.cacheUrl,
           emailTarget = theme.emailTarget,
-          homePage = theme.homePage, metadataPrefix = theme.metadataPrefix)
+          homePage = theme.homePage)
         )
         inserted match {
           case Some(id) => Some(theme.copy(id = inserted))
@@ -96,8 +95,7 @@ object Themes extends DelvingController with AdminSecure {
           solrSelectUrl = theme.solrSelectUrl,
           cacheUrl = theme.cacheUrl,
           emailTarget = theme.emailTarget,
-          homePage = theme.homePage,
-          metadataPrefix = theme.metadataPrefix)
+          homePage = theme.homePage)
         PortalTheme.save(updated)
         Some(theme)
       }

--- a/app/controllers/organization/DataSetControl.scala
+++ b/app/controllers/organization/DataSetControl.scala
@@ -38,11 +38,11 @@ object DataSetControl extends DelvingController with OrganizationSecured {
     val dataSet = DataSet.findBySpecAndOrgId(spec, orgId)
 
     val data = if (dataSet == None)
-      JJson.generate(ShortDataSet(userName = connectedUser, orgId = orgId))
+      JJson.generate(ShortDataSet(userName = connectedUser, orgId = orgId, indexingMappingPrefix = ""))
     else {
       val dS = dataSet.get
       if(DataSet.canEdit(dS, connectedUser)) {
-        JJson.generate(ShortDataSet(id = Some(dS._id), spec = dS.spec, facts = dS.getFacts, userName = dS.getCreator.userName, orgId = dS.orgId, recordDefinitions = dS.recordDefinitions, visibility = dS.visibility.value))
+        JJson.generate(ShortDataSet(id = Some(dS._id), spec = dS.spec, facts = dS.getFacts, userName = dS.getCreator.userName, orgId = dS.orgId, recordDefinitions = dS.recordDefinitions, indexingMappingPrefix = dS.getIndexingMappingPrefix, visibility = dS.visibility.value))
       } else {
         return Forbidden("You are not allowed to edit DataSet %s".format(spec))
       }
@@ -54,9 +54,19 @@ object DataSetControl extends DelvingController with OrganizationSecured {
   def dataSetSubmit(orgId: String, data: String): Result = {
     val dataSet = JJson.parse[ShortDataSet](data)
     val spec: String = dataSet.spec
+
+    // TODO validation!
+
     if("^[A-Za-z0-9-]{3,40}$".r.findFirstIn(spec) == None) {
-      return JsonBadRequest(JJson.generate(dataSet.copy(errors = Map("spec" -> "Invalid spec format!"))))
+      return JsonBadRequest(JJson.generate(dataSet.copy(errors = Map("ds.spec" -> "Invalid spec format!"))))
     }
+
+    if(dataSet.indexingMappingPrefix.trim.isEmpty || !dataSet.recordDefinitions.contains(dataSet.indexingMappingPrefix)) {
+      return JsonBadRequest(JJson.generate(dataSet.copy(errors = Map("ds.indexingMappingPrefix" -> "Choose an indexing mapping prefix!"))))
+    }
+
+
+
     val factsObject = new BasicDBObject(dataSet.facts)
 
     def buildMappings(recordDefinitions: List[String]): Map[String, Mapping] = {
@@ -83,7 +93,12 @@ object DataSetControl extends DelvingController with OrganizationSecured {
         if(!DataSet.canEdit(existing, connectedUser)) return Forbidden("You have no rights to edit this DataSet")
 
         val updatedDetails = existing.details.copy(facts = factsObject)
-        val updated = existing.copy(spec = spec, details = updatedDetails, mappings = updateMappings(dataSet.recordDefinitions, existing.mappings), visibility = Visibility.get(dataSet.visibility))
+        val updated = existing.copy(
+          spec = spec,
+          details = updatedDetails,
+          mappings = updateMappings(dataSet.recordDefinitions, existing.mappings),
+          idxMappings = List(dataSet.indexingMappingPrefix),
+          visibility = Visibility.get(dataSet.visibility))
         DataSet.save(updated)
         }
       case None =>
@@ -103,7 +118,8 @@ object DataSetControl extends DelvingController with OrganizationSecured {
             facts = factsObject,
             metadataFormat = RecordDefinition("raw", "http://delving.eu/namespaces/raw", "http://delving.eu/namespaces/raw/schema.xsd")
           ),
-          mappings = buildMappings(dataSet.recordDefinitions)
+          mappings = buildMappings(dataSet.recordDefinitions),
+          idxMappings = List(dataSet.indexingMappingPrefix)
         )
       )
     }

--- a/app/controllers/search/SolrQueryService.scala
+++ b/app/controllers/search/SolrQueryService.scala
@@ -469,7 +469,7 @@ case class DelvingIdType(id: String, idType: String) {
     case "drupal" => "id" // maybe later drup_id
     case "dataSetId" => HUB_ID
     case "hubId" => HUB_ID
-    case "legacy" => "europeana_uri"
+    case "legacy" => EUROPEANA_URI
     case _ => PMH_ID
   }
   lazy val normalisedId = idSearchField match {

--- a/app/controllers/user/Links.scala
+++ b/app/controllers/user/Links.scala
@@ -175,7 +175,7 @@ object Links extends DelvingController {
                 collection.findOne(MongoDBObject("localRecordKey" -> recordId)) match {
                   case Some(one) =>
                     val mdr = grater[MetadataRecord].asObject(one)
-                    Indexing.indexOneInSolr(orgId, spec, theme.metadataPrefix.getOrElse(""), mdr)
+                    Indexing.indexOneInSolr(orgId, spec, mdr)
                   case None => // huh?
                     warning("MDR %s_%s_%s does not exist!", orgId, spec, recordId)
                 }

--- a/app/jobs/DatasetIndexing.scala
+++ b/app/jobs/DatasetIndexing.scala
@@ -35,8 +35,8 @@ class DataSetIndexing extends Job {
     if (play.Play.started) {
       val dataSet = DataSet.findCollectionForIndexing()
       if (dataSet != None) {
-        dataSet.get.idxMappings foreach {
-          prefix =>
+        dataSet.get.getIndexingMappingPrefix match {
+          case Some(prefix) =>
             try {
               Indexing.indexInSolr(dataSet.get, prefix)
             } catch {
@@ -45,6 +45,9 @@ class DataSetIndexing extends Job {
                 DataSet.updateState(dataSet.get, DataSetState.ERROR)
               }
             }
+          case None =>
+            Logger.error("No indexing mapping prefix set for DataSet " + dataSet.get.spec)
+            DataSet.updateState(dataSet.get, DataSetState.ERROR)
         }
       }
     }

--- a/app/models/DataSet.scala
+++ b/app/models/DataSet.scala
@@ -75,10 +75,7 @@ case class DataSet(_id: ObjectId = new ObjectId,
     initialFacts ++ storedFacts
   }
   
-  def getIndexingMappingPrefix = idxMappings.headOption match {
-    case Some(thing) => thing
-    case None => throw new RuntimeException("DataSet without indexing mapping!")
-  }
+  def getIndexingMappingPrefix = idxMappings.headOption
 
   def hasHash(hash: String): Boolean = hashes.values.filter(h => h == hash).nonEmpty
 
@@ -267,7 +264,7 @@ object DataSet extends SalatDAO[DataSet, ObjectId](collection = dataSetsCollecti
   def getStateBySpecAndOrgId(spec: String, orgId: String) = DataSet.findBySpecAndOrgId(spec, orgId).get.state
 
   def changeState(dataSet: DataSet, state: DataSetState): DataSet = {
-    val dataSetLatest = DataSet.findBySpec(dataSet.spec).get
+    val dataSetLatest = DataSet.findBySpecAndOrgId(dataSet.spec, dataSet.orgId).get
     val mappings = dataSetLatest.mappings.transform((key, map) => map.copy(rec_indexed = 0))
     val updatedDataSet = dataSetLatest.copy(state = state, mappings = mappings)
     DataSet.save(updatedDataSet)

--- a/app/models/DataSet.scala
+++ b/app/models/DataSet.scala
@@ -57,7 +57,7 @@ case class DataSet(_id: ObjectId = new ObjectId,
                    hashes: Map[String, String] = Map.empty[String, String],
                    namespaces: Map[String, String] = Map.empty[String, String],
                    mappings: Map[String, Mapping] = Map.empty[String, Mapping],
-                   idxMappings: List[String] = List.empty[String],
+                   idxMappings: List[String] = List.empty[String], // the mapping(s) used at indexing time (for the moment, use only one)
                    idxFacets: List[String] = List.empty[String],
                    idxSortFields: List[String] = List.empty[String],
                    hints: Array[Byte] = Array.empty[Byte],
@@ -73,6 +73,11 @@ case class DataSet(_id: ObjectId = new ObjectId,
     val initialFacts = (DataSet.factDefinitionList.map(factDef => (factDef.name, ""))).toMap[String, String]
     val storedFacts = (for (fact <- details.facts) yield (fact._1, fact._2.toString)).toMap[String, String]
     initialFacts ++ storedFacts
+  }
+  
+  def getIndexingMappingPrefix = idxMappings.headOption match {
+    case Some(thing) => thing
+    case None => throw new RuntimeException("DataSet without indexing mapping!")
   }
 
   def hasHash(hash: String): Boolean = hashes.values.filter(h => h == hash).nonEmpty

--- a/app/models/DrupalEntity.scala
+++ b/app/models/DrupalEntity.scala
@@ -61,7 +61,7 @@ case class DrupalEntity(_id: ObjectId = new ObjectId, rawXml: String, id: Drupal
     doc addField("drup_id_string", id.id)
     doc addField ("drup_entityType_string", id.nodeType)
     doc addField ("drup_bundle_string", id.bundle)
-    doc addField ("europeana_uri", id.nodeId)
+    doc addField (EUROPEANA_URI, id.nodeId)
     doc addField ("europeana_collectionName_s", id.bundle)
     doc addField ("europeana_provider_s", "ITIN")
     doc addField (ORG_ID, "ifthenisnow")

--- a/app/models/PortalTheme.scala
+++ b/app/models/PortalTheme.scala
@@ -43,14 +43,7 @@ case class PortalTheme(_id:                                 ObjectId = new Objec
                        homePage:                            Option[String] = None,
                        facets:                              Option[String] = None, // dc_creator:crea:Creator,dc_type
                        sortFields:                          Option[String] = None, // dc_creator,dc_provider:desc
-                       metadataPrefix:                      Option[String] = None,
                        apiWsKey:                            Boolean = false) {
-
-
-
-  def getRecordDefinition: eu.delving.metadata.RecordDefinition = {
-      ComponentRegistry.metadataModel.asInstanceOf[MetadataModelImpl].getRecordDefinition(metadataPrefix.get)
-  }
 
   def getFacets: List[SolrFacetElement] = {
     facets.getOrElse("").split(",").filter(k => k.split(":").size > 0 && k.split(":").size < 4).map {

--- a/app/util/Constants.scala
+++ b/app/util/Constants.scala
@@ -39,6 +39,7 @@ object Constants {
   val HUB_ID = "delving_hubId"
   val PMH_ID = "delving_pmhId"
   val ORG_ID = "delving_orgId"
+  val EUROPEANA_URI = "europeana_uri"
 
   val SPEC = "delving_spec"
   val FORMAT = "delving_currentFormat"

--- a/app/views/organization/DataSetControl/dataSet.html
+++ b/app/views/organization/DataSetControl/dataSet.html
@@ -44,10 +44,15 @@ isOwner: isOwner /}
                     %{ }}%
                 </div>
                 <div class="g-6of12 grid_6">
-                    <h3>Record Definitions</h3>
+                    <h3>Target Record Definitions</h3>
                     #{list recordDefinitions, as: 'recordDef'}
                     #{checkboxField name: recordDef + "_field", label: recordDef, value: recordDef, dataBind: "checked: recordDefinitions" /}
                     #{/list}
+                </div>
+                <div class="g-6of12 grid_6">
+                    <h3>Indexing Mapping Record Definition</h3>
+                    <select id="mapping-prefix" name="mapping-prefix" data-bind="options: recordDefinitions, optionsCaption: 'Select a mapping for indexing', value: indexingMappingPrefix"></select>
+                    <span class="error" data-bind="text: errors().indexingMappingPrefix"></span>
                 </div>
             </div>
             <div class="row">
@@ -67,7 +72,7 @@ isOwner: isOwner /}
                 handleSubmit('/organizations/${orgId}/dataset/submit', dataSetModel, '#collectionForm', null, function() {
                     window.location.href = '/organizations/${orgId}/dataset/' + dataSetModel.spec.call();
                 }, function() {
-                    alert("Could not save dataset! Maybe an invalid spec was passed in? (this message will get better very soon)")
+                    alert("Could not save dataset! Maybe an invalid spec was passed in or no mapping was selected for indexing?")
                 });
             });
 

--- a/conf/default_themes.yml
+++ b/conf/default_themes.yml
@@ -18,5 +18,4 @@
     homePage:
     facets: delving_recordType:metadata.searchfield.recordType,europeana_provider:metadata.searchfield.dataprovider,delving_creator:metadata.searchfield.creator,delving_hasDigitalObject:metadata.searchfield.hasDigitalObject
     sortFields: delving_hasDigitalObject
-    metadataPrefix: icn
     apiWsKey: false

--- a/conf/testData.yml
+++ b/conf/testData.yml
@@ -104,6 +104,7 @@
         ? icn
         : *icnMapping
     hints: ""
+    idxMappings: ["icn"]
     invalidRecords: !!map { }
 
 - !!models.DataSet
@@ -155,6 +156,7 @@
     mappings:
         ? icn
         : *icnMapping
+    idxMappings: ["icn"]
     hints: ""
     invalidRecords: !!map { }
 


### PR DESCRIPTION
Moves the mapping prefix from PortalTheme to DataSet.

You need to run this on each culturehub db as an evolution:

```
db.Datasets.find({idxMappings: {$exists: false}}).forEach(function(it){it.idxMappings = ["icn"]; db.Datasets.save(it);})
```

And then make sure the selected mapping is correct in the DataSet interface
