### PR TITLE
Use heritage objects in Collections and Stories

### DIFF
--- a/app/controllers/MetadataAccessors.scala
+++ b/app/controllers/MetadataAccessors.scala
@@ -62,18 +62,12 @@ abstract class MetadataAccessors extends Universal {
   }
   def getThumbnailUri: String = getThumbnailUri(180)
   def getThumbnailUri(size: Int): String = {
-    getRecordType match {
-      case OBJECT | USERCOLLECTION | STORY => assign(THUMBNAIL) match {
-          case id if ObjectId.isValid(id) && !id.trim.isEmpty =>
-            val mongoId = Some(new ObjectId(id))
-            thumbnailUrl(mongoId, size)
-          case _ => thumbnailUrl(None, size)
-        }
+    assign(THUMBNAIL) match {
+      case id if ObjectId.isValid(id) && !id.trim.isEmpty =>
+        val mongoId = Some(new ObjectId(id))
+        thumbnailUrl(mongoId, size)
       // TODO plug-in the image cache here for MDRs
-      case MDR => assign(THUMBNAIL) match {
-        case url if url.trim.length() > 0 => url
-        case _ => thumbnailUrl(None, size)
-      }
+      case url if url.startsWith("http") => url
       case _ => thumbnailUrl(None, size)
     }
   }

--- a/app/controllers/ModelImplicits.scala
+++ b/app/controllers/ModelImplicits.scala
@@ -52,6 +52,9 @@ trait ModelImplicits extends Internationalization {
   implicit def objectToShortObjectModel(o: DObject): ShortObjectModel = ShortObjectModel(o._id, o.url, thumbnailUrl(o.thumbnail_id), o.name, util.Constants.OBJECT)
   implicit def objectListToShortObjectModelList(l: List[DObject]): List[ShortObjectModel] = l.map { objectToShortObjectModel(_) }
 
+  implicit def mdrAccessorToShortObjectModel(record: MultiValueMapMetadataAccessors) = ShortObjectModel(id = record.getHubId, url = record.getUri, thumbnail = record.getThumbnailUri(80), title = record.getTitle, hubType = MDR)
+  implicit def mdrAccessorListToSOMList(records: List[MultiValueMapMetadataAccessors]) = records.map(mdrAccessorToShortObjectModel(_))
+
   // ~~ ListItems
 
   implicit def objectToListItem(o: DObject): ListItem = ListItem(o._id, OBJECT, o.name, o.description, Some(o._id), None, o.userName, o.visibility == Visibility.PRIVATE, o.url)

--- a/app/controllers/ModelImplicits.scala
+++ b/app/controllers/ModelImplicits.scala
@@ -55,8 +55,8 @@ trait ModelImplicits extends Internationalization {
   // ~~ ListItems
 
   implicit def objectToListItem(o: DObject): ListItem = ListItem(o._id, OBJECT, o.name, o.description, Some(o._id), None, o.userName, o.visibility == Visibility.PRIVATE, o.url)
-  implicit def collectionToListItem(c: UserCollection) = ListItem(c._id, USERCOLLECTION, c.name, c.description, c.thumbnail_id, None, c.userName, c.visibility == Visibility.PRIVATE, c.url)
-  implicit def storyToListItem(s: Story) = ListItem(s._id, STORY, s.name, s.description, s.thumbnail_id, None,  s.userName, s.visibility == Visibility.PRIVATE, s.url)
+  implicit def collectionToListItem(c: UserCollection) = ListItem(c._id, USERCOLLECTION, c.name, c.description, c.thumbnail_id, c.thumbnail_url, c.userName, c.visibility == Visibility.PRIVATE, c.url)
+  implicit def storyToListItem(s: Story) = ListItem(s._id, STORY, s.name, s.description, s.thumbnail_id, s.thumbnail_url,  s.userName, s.visibility == Visibility.PRIVATE, s.url)
   implicit def userToListItem(u: User) = ListItem(u._id, USER, u.fullname, u.email, None, None,  u.userName, false, "/" + u.userName)
   implicit def dataSetToListItem(ds: DataSet) = ListItem(ds.spec, DATASET, ds.details.name, ds.description.getOrElse(""), None, None, ds.getCreator.userName, false, "/nope")
 

--- a/app/controllers/Registration.scala
+++ b/app/controllers/Registration.scala
@@ -104,6 +104,7 @@ object Registration extends Controller with ThemeAware with Internationalization
               description = "Bookmarks",
               visibility = Visibility.PRIVATE,
               thumbnail_id = None,
+              thumbnail_url = None,
               isBookmarksCollection = Some(true))
             val userCollectionId = UserCollection.insert(bookmarksCollection)
             Mails.activation(newUser, activationToken)

--- a/app/controllers/user/Links.scala
+++ b/app/controllers/user/Links.scala
@@ -155,7 +155,7 @@ object Links extends DelvingController {
                     refType = Some("institutionalObject"), // TODO need TW blessing
                     hubType = Some(MDR),
                     hubCollection = Some(collection.getName()),
-                    hubAlternativeId = Some(recordId)
+                    hubAlternativeId = Some("%s_%s_%s".format(orgId, spec, recordId))
                   ),
                   to = LinkReference(
                     id = Some(collectionId),

--- a/app/controllers/user/Links.scala
+++ b/app/controllers/user/Links.scala
@@ -166,7 +166,11 @@ object Links extends DelvingController {
                     id = mdr._id
                   )),
                   embedTo = Some(EmbeddedLinkWriter(
-                    value = Some(Map(HUB_ID -> mdr.get(MDR_HUB_ID).toString, MDR_LOCAL_ID -> mdr.get(MDR_LOCAL_ID).toString, MDR_HUBCOLLECTION -> collection.getName())),
+                    value = Some(Map(
+                      MDR_HUB_ID -> mdr.get(MDR_HUB_ID).toString,
+                      MDR_LOCAL_ID -> mdr.get(MDR_LOCAL_ID).toString,
+                      MDR_HUBCOLLECTION -> collection.getName())
+                    ),
                     collection = userCollectionsCollection,
                     id = Some(collectionId))
                   ))

--- a/app/controllers/user/Stories.scala
+++ b/app/controllers/user/Stories.scala
@@ -25,6 +25,7 @@ import play.data.validation.Annotations._
 import java.util.Date
 import extensions.JJson
 import util.Constants._
+import views.context.DEFAULT_THUMBNAIL
 
 /**
  *
@@ -65,10 +66,11 @@ object Stories extends DelvingController with UserSecured with UGCController {
     def findThumbnailUrl(thumbnailId: String) = {
       thumbnailId match {
         case oid if ObjectId.isValid(oid) => None // it's an object ID
-        case hubId => MetadataRecord.getMDR(hubId) match {
+        case hubId if hubId.count(_ == '_') == 2 => MetadataRecord.getMDR(hubId) match {
           case Some(m) => Some(m.getDefaultAccessor.getThumbnailUri)
           case None => None
         }
+        case _ => Some(DEFAULT_THUMBNAIL)
       }
     }
     

--- a/app/controllers/user/Stories.scala
+++ b/app/controllers/user/Stories.scala
@@ -75,6 +75,7 @@ object Stories extends DelvingController with UserSecured {
           userName = connectedUser,
           visibility = Visibility.get(storyVM.visibility.intValue()),
           thumbnail_id = thumbnail,
+          thumbnail_url = None, // TODO
           pages = pages,
           isDraft = storyVM.isDraft)
         val inserted = Story.insert(story)

--- a/app/controllers/user/UGCController.scala
+++ b/app/controllers/user/UGCController.scala
@@ -61,7 +61,7 @@ trait UGCController { self: DelvingController =>
     }
   }
 
-  def retrieveMDRs(links: List[Link]) = {
+  def retrieveMDRs(links: List[Link]): List[ShortObjectModel] = {
     val mdrIds = links.filter(_.from.hubType == Some(MDR)).map(l => (l.from.hubCollection.get, l.from.hubAlternativeId.get))
     val mdrs = mdrIds.groupBy(_._1).map(m => connection(m._1).find(MDR_HUB_ID $in m._2.map(_._2)).toList).flatten.map(grater[MetadataRecord].asObject(_))
     mdrs.flatMap(mdr =>

--- a/app/controllers/user/UGCController.scala
+++ b/app/controllers/user/UGCController.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2011 Delving B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.user
+
+import org.bson.types.ObjectId
+import com.mongodb.casbah.Imports._
+import _root_.util.Constants._
+import models.salatContext._
+import com.novus.salat.grater
+import controllers.{ShortObjectModel, DelvingController}
+import models._
+import views.context.DEFAULT_THUMBNAIL
+import util.ProgrammerException
+
+/**
+ * Common operations amongst UGC controllers.
+ *
+ * TODO move this where it actually belongs to
+ *
+ * @author Manuel Bernhardt <bernhardt.manuel@gmail.com>
+ */
+
+trait UGCController { self: DelvingController =>
+
+  def getThumbnailId(collectionId: ObjectId, thumbnailId: String, thumbnailUrl: Option[String]) = thumbnailId match {
+    case oid if ObjectId.isValid(oid) => Right(new ObjectId(oid))
+    case hubId if hubId.count(_ == '_') == 3 => Left(thumbnailUrl.getOrElse(DEFAULT_THUMBNAIL))
+    case _ => Left(DEFAULT_THUMBNAIL)
+  }
+
+  def setThumbnaiL(fromId: ObjectId, fromType: String, thumbnailId: String, thumbnailUrl: Option[String], thumbnailLink: Option[ObjectId]) {
+    // remove existing thumbnail link, if any
+    thumbnailLink.foreach(Link.removeById(_))
+
+    val collection = fromType match {
+      case USERCOLLECTION => userCollectionsCollection
+      case STORY => userStoriesCollection
+      case _ => throw new ProgrammerException("Wrong fromType for thumbnail")
+    }
+
+    getThumbnailId(fromId, thumbnailId, thumbnailUrl) match {
+      case Right(oid: ObjectId) =>
+        collection.update(MongoDBObject("_id" -> fromId), $set ("thumbnail_id" -> oid) ++ $unset("thumbnail_url"))
+      case Left(url: String) =>
+        Link.createThumbnailLink(fromId, fromType, thumbnailId, connectedUser)
+        collection.update(MongoDBObject("_id" -> fromId), $set("thumbnail_url" -> url) ++ $unset("thumbnail_id"))
+    }
+  }
+
+  def retrieveMDRs(links: List[Link]) = {
+    val mdrIds = links.filter(_.from.hubType == Some(MDR)).map(l => (l.from.hubCollection.get, l.from.hubAlternativeId.get))
+    val mdrs = mdrIds.groupBy(_._1).map(m => connection(m._1).find(MDR_HUB_ID $in m._2.map(_._2)).toList).flatten.map(grater[MetadataRecord].asObject(_))
+    mdrs.flatMap(mdr =>
+      // we assume that the first mapping we find will do
+      if(!mdr.mappedMetadata.isEmpty) {
+        val Array(orgId, spec, localRecordKey) = mdr.hubId.split("_")
+        DataSet.findBySpecAndOrgId(spec, orgId) match {
+          case Some(ds) =>
+            val record = mdr.getAccessor(ds.getIndexingMappingPrefix.getOrElse(""))
+            Some(record)
+          case None =>
+            warning("Could not find DataSet for " + mdr.hubId)
+            None // huh?!?
+        }
+      } else {
+        None
+      }).toList
+  }
+
+}

--- a/app/controllers/user/UGCController.scala
+++ b/app/controllers/user/UGCController.scala
@@ -38,13 +38,17 @@ trait UGCController { self: DelvingController =>
 
   def getThumbnailId(collectionId: ObjectId, thumbnailId: String, thumbnailUrl: Option[String]) = thumbnailId match {
     case oid if ObjectId.isValid(oid) => Right(new ObjectId(oid))
-    case hubId if hubId.count(_ == '_') == 3 => Left(thumbnailUrl.getOrElse(DEFAULT_THUMBNAIL))
+    case hubId if hubId.count(_ == '_') == 2 => Left(thumbnailUrl.getOrElse(DEFAULT_THUMBNAIL))
     case _ => Left(DEFAULT_THUMBNAIL)
   }
 
   def setThumbnaiL(fromId: ObjectId, fromType: String, thumbnailId: String, thumbnailUrl: Option[String], thumbnailLink: Option[ObjectId]) {
     // remove existing thumbnail link, if any
     thumbnailLink.foreach(Link.removeById(_))
+
+    if(thumbnailId.length() == 0) {
+      return
+    }
 
     val collection = fromType match {
       case USERCOLLECTION => userCollectionsCollection

--- a/app/models/DObject.scala
+++ b/app/models/DObject.scala
@@ -38,6 +38,7 @@ case class DObject(_id: ObjectId = new ObjectId,
                    visibility: Visibility,
                    deleted: Boolean = false,
                    thumbnail_id: Option[ObjectId],
+                   thumbnail_url: Option[String] = None,
                    links: List[EmbeddedLink] = List.empty[EmbeddedLink],
                    thumbnail_file_id: Option[ObjectId] = None, // pointer to the file selected as the thumbnail. This is _not_ helping to fetch the thumbnail, which is retrieved using the ID of the object
                    files: Seq[StoredFile] = Seq.empty[StoredFile]) extends Thing {

--- a/app/models/Link.scala
+++ b/app/models/Link.scala
@@ -135,16 +135,18 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
     }
   }
 
+  def hubTypeToCollection(hubType: String) = Option(hubType match {
+    case OBJECT => objectsCollection
+    case USERCOLLECTION => userCollectionsCollection
+    case STORY => userStoriesCollection
+    case USER => userCollection
+    case _ => null
+  })
+
   def removeLink(link: Link) {
     
     def removeEmbedded(link: ObjectId, hubType: String, id: Option[ObjectId], hubCollection: Option[String], hubAlternativeId: Option[String]) {
-      val collection: Option[MongoCollection] = Option(hubType match {
-        case OBJECT => objectsCollection
-        case USERCOLLECTION => userCollectionsCollection
-        case STORY => userStoriesCollection
-        case USER => userCollection
-        case _ => null
-      })
+      val collection: Option[MongoCollection] = hubTypeToCollection(hubType)
       val pull = $pull ("links" -> MongoDBObject("link" -> link))
       collection match {
         case Some(c) =>

--- a/app/models/Link.scala
+++ b/app/models/Link.scala
@@ -45,6 +45,7 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
     val FREETEXT = "freeText"
     val PLACE = "place"
     val PARTOF = "partOf"
+    val THUMBNAIL = "thumbnail" // special internal link to denote usage as thumbnail
   }
 
   /**
@@ -150,7 +151,7 @@ object Link extends SalatDAO[Link, ObjectId](linksCollection) {
           c.update(MongoDBObject("_id" -> id.get), pull)
         case None =>
           if(hubType == MDR && hubCollection.isDefined && hubAlternativeId.isDefined) {
-            connection(hubCollection.get).update(MongoDBObject(MDR_LOCAL_ID -> hubAlternativeId.get), pull)
+            connection(hubCollection.get).update(MongoDBObject(MDR_HUB_ID -> hubAlternativeId.get), pull)
           } else {
             Logger.warn("Could not delete embedded Link %s %s %s", hubType, id, hubCollection)
           }

--- a/app/models/Story.scala
+++ b/app/models/Story.scala
@@ -37,6 +37,7 @@ case class Story(_id: ObjectId = new ObjectId,
                  visibility: Visibility,
                  deleted: Boolean = false,
                  thumbnail_id: Option[ObjectId],
+                 thumbnail_url: Option[String],
                  isDraft: Boolean,
                  pages: List[Page],
                  links: List[EmbeddedLink] = List.empty[EmbeddedLink]) extends Thing {

--- a/app/models/Story.scala
+++ b/app/models/Story.scala
@@ -22,6 +22,7 @@ import models.salatContext._
 import org.bson.types.ObjectId
 import java.util.Date
 import util.Constants._
+import controllers.{ModelImplicits, ShortObjectModel}
 
 /**
  *
@@ -63,7 +64,19 @@ object Story extends SalatDAO[Story, ObjectId](userStoriesCollection) with Commo
 
 }
 
-case class Page(title: String, text: String, objects: List[PageObject])
+case class Page(title: String, text: String, objects: List[PageObject]) extends ModelImplicits {
 
-/**object in a page. may contain more things such as position, location, ... **/
-case class PageObject(dobject_id: ObjectId)
+  def getPageObjects = {
+    val (userPageObjects, mdrPageObjects) = objects.partition(_.objectId != None)
+    val userObjects: List[ShortObjectModel] = DObject.findAllWithIds(userPageObjects.flatMap(_.objectId)).toList
+    // TODO optimize, refactor
+    val heritageObjects: List[ShortObjectModel] = mdrPageObjects.flatMap(_.hubId).flatMap(MetadataRecord.getMDR(_)).map(_.getDefaultAccessor)
+    userObjects ++ heritageObjects
+  }
+
+}
+
+/**
+ * References an object in a page, either a UserObject or MDR. May contain additional information such as position in the page etc.
+ */
+case class PageObject(objectId: Option[ObjectId] = None, hubId: Option[String] = None)

--- a/app/models/Thing.scala
+++ b/app/models/Thing.scala
@@ -84,6 +84,16 @@ trait Thing extends Base with Universal {
   def getMimeType = "unknown/unknown"
   def hasDigitalObject = thumbnail_id != None || thumbnail_url != None
 
+  // ~~~ special (internal) accessors:
+  def getThumbnailIdInternal: String = {
+    if(thumbnail_id != None) thumbnail_id.get.toString else {
+      links.find(_.linkType == Link.LinkType.THUMBNAIL).headOption match {
+        case Some(e) => e.value(MDR_HUB_ID)
+        case None => ""
+      }
+    }
+  }
+
   protected def getAsSolrDocument: SolrInputDocument = {
     val doc = new SolrInputDocument
     doc addField (ID, _id)

--- a/app/models/UserCollection.scala
+++ b/app/models/UserCollection.scala
@@ -55,30 +55,4 @@ object UserCollection extends SalatDAO[UserCollection, ObjectId](userCollections
     userCollectionsCollection.update(MongoDBObject("_id" -> id), $set("linkedObjects" -> objectIds))
   }
 
-  def createThumbnailLink(userCollection: ObjectId, hubId: String, userName: String) = {
-    val Array(orgId, spec, recordId) = hubId.split("_")
-    val mdrCollectionName = DataSet.getRecordsCollectionName(orgId, spec)
-
-    Link.create(
-      linkType = Link.LinkType.THUMBNAIL,
-      userName = userName,
-      value = Map.empty,
-      from = LinkReference(
-        id = Some(userCollection),
-        hubType = Some(USERCOLLECTION)
-      ),
-      to = LinkReference(
-        hubType = Some(MDR),
-        hubCollection = Some(mdrCollectionName),
-        hubAlternativeId = Some(hubId)
-      ),
-      embedFrom = Some(EmbeddedLinkWriter(
-        value = Some(Map(MDR_HUB_ID -> hubId)),
-        collection = userCollectionsCollection,
-        id = Some(userCollection)
-      ))
-    )
-
-  }
-
 }

--- a/app/views/Collections/collection.html
+++ b/app/views/Collections/collection.html
@@ -10,7 +10,7 @@
     <div class="g-12of12 grid_12">
         <div class="dashboard">
         <div class="media record">
-            <img src="${views.context.package.thumbnailUrl(collection.thumbnail_id, 350)}" width="350" alt="${collection.name}" class="img"/>
+            <img src="${collection.getThumbnailUri(350)}" width="350" alt="${collection.name}" class="img"/>
 
             <div class="extra">
                 #{if objects.length() > 0}

--- a/app/views/Stories/read.html
+++ b/app/views/Stories/read.html
@@ -83,8 +83,8 @@
                             </div>
                             <div class="page-right g-1of2 omega images">
                                 *{#{list page.objects.headOption(), as: 'o'}}*
-                                #{list page.objects, as: 'o'}
-                                <img src="${views.context.package.imageUrl(o.dobject_id)}" id="img_${o_index}" width="340" alt="${page.title}">
+                                #{list page.getPageObjects(), as: 'o'}
+                                <img src="${o.thumbnail()}" id="img_${o_index}" width="340" alt="${page.title}">
                                 #{/list}
                             </div>
 

--- a/app/views/Stories/story.html
+++ b/app/views/Stories/story.html
@@ -7,7 +7,7 @@
     <div class="g-12of12 grid_12">
         <div class="dashboard">
             <div class="media record">
-                <img src='${views.context.package.thumbnailUrl(story.thumbnail_id, 350)}' width="350" alt="${story.name}" class="img"/>
+                <img src='${story.getThumbnailUri(350)}' width="350" alt="${story.name}" class="img"/>
 
                 <div class="extra">
                     <a href="/${story.userName}/story/${story._id}/read">

--- a/app/views/package.scala
+++ b/app/views/package.scala
@@ -23,11 +23,12 @@ import models.{UserCollection, DObject, PortalTheme}
 import java.util.Date
 import java.text.SimpleDateFormat
 import controllers.dos.ImageDisplay
-import play.mvc.{Util, Http}
+import play.mvc.Http
 import controllers.{ViewUtils, Internationalization, ViewModel}
 
 package object context extends Internationalization {
 
+  val DEFAULT_THUMBNAIL = "/public/images/dummy-object.png"
   val PAGE_SIZE = 12
 
   // ~~~ play variables
@@ -59,7 +60,7 @@ package object context extends Internationalization {
 
   def thumbnailUrl(thumbnail: Option[ObjectId], size: Int = 100) = thumbnail match {
     case Some(t) => "/thumbnail/%s/%s".format(t, size)
-    case None => "/public/images/dummy-object.png" // TODO now that's not very clean, is it?
+    case None => DEFAULT_THUMBNAIL // TODO now that's not very clean, is it?
   }
 
   def imageUrl(image: ObjectId) = if(ImageDisplay.imageExists(image)) "/image/" + image else "/public/images/dummy-object.png" // TODO now that's not very clean, is it?

--- a/app/views/user/Collections/collection.html
+++ b/app/views/user/Collections/collection.html
@@ -15,36 +15,31 @@
     <form method="post" action="" id="collectionForm">
 
     <fieldset>
-    <legend><span>&{'user.collection.info'}</span></legend>
-
-    #{textField name:"name", label:viewUtils.getKey('thing.name'), dataBind:"value: name, disable: isBookmarksCollection", labelClass:"required", required: true /}
-    #{textArea name:"description", label:viewUtils.getKey('thing.description'), dataBind:"value: description, disable: isBookmarksCollection", required: true, help:viewUtils.getKey('user.collection.help.description') /}
+        <legend><span>&{'user.collection.info'}</span></legend>
+        #{textField name:"name", label:viewUtils.getKey('thing.name'), dataBind:"value: name, disable: isBookmarksCollection", labelClass:"required", required: true /}
+        #{textArea name:"description", label:viewUtils.getKey('thing.description'), dataBind:"value: description, disable: isBookmarksCollection", required: true, help:viewUtils.getKey('user.collection.help.description') /}
     </fieldset>
 
     <fieldset>
-    <legend><span>&{'user.collection.objects'}</span></legend>
-    <div class="buttons">
-        #{btnHref label:viewUtils.getKey('user.collection.label.addObjects'), iconClass:"icon3", id:"addObject" /}
-    </div>
-
-    <div id="objectList" class="data-grid mam" data-bind="template: {name:'objectsList', templateOptions: {title: '&{'user.collection.title.objectsList'}', objects: objects, thumbnail: thumbnail} }"></div>
-
-    <div class="objects-container" id="objects-dialogue" title="&{'user.collection.label.addObjects'}">
-        <div id="objects-list" data-bind="template: {name: 'availableObjectsList', templateOptions: {selectedIds: selectedObjects, availableObjects: availableObjects}}"></div>
-    </div>
+        <legend><span>&{'user.collection.objects'}</span></legend>
+        <div class="buttons">
+            #{btnHref label:viewUtils.getKey('user.collection.label.addObjects'), iconClass:"icon3", id:"addObject" /}
+        </div>
+        <div id="objectList" class="data-grid mam" data-bind="template: {name:'objectsList', templateOptions: {title: '&{'user.collection.title.objectsList'}', objects: objects, thumbnail: thumbnail} }"></div>
+        <div class="objects-container" id="objects-dialogue" title="&{'user.collection.label.addObjects'}">
+            <div id="objects-list" data-bind="template: {name: 'availableObjectsList', templateOptions: {selectedIds: selectedObjects, availableObjects: availableObjects}}"></div>
+        </div>
     </fieldset>
     <fieldset>
         <legend><span>&{'user.collection.status'}</span></legend>
-    <div class="field" for="objectVisibility">
-        <label class="label">&{'ui.label.visibility'}</label>
-
-        <div class="inputs">
-            <input type="radio" name="public" value="${models.Visibility.PRIVATE().value}" data-bind="checked: visibility, disable: isBookmarksCollection"/>&{'ui.label.visibility.notpublic'} <br/>
-            <input type="radio" name="public" value="${models.Visibility.PUBLIC().value}" data-bind="checked: visibility, disable: isBookmarksCollection"/>&{'ui.label.visibility.public'}
+        <div class="field" for="objectVisibility">
+            <label class="label">&{'ui.label.visibility'}</label>
+            <div class="inputs">
+                <input type="radio" name="public" value="${models.Visibility.PRIVATE().value}" data-bind="checked: visibility, disable: isBookmarksCollection"/>&{'ui.label.visibility.notpublic'} <br/>
+                <input type="radio" name="public" value="${models.Visibility.PUBLIC().value}" data-bind="checked: visibility, disable: isBookmarksCollection"/>&{'ui.label.visibility.public'}
+            </div>
         </div>
-    </div>
     </fieldset>
-
 
     <div class="buttons">
         #{btnButton label: viewUtils.getKey('ui.label.cancel'), extraClass:"cancelButton beware", id:"cancelButton", type:"reset" /}

--- a/public/common/templates/_selectedObjects.tmpl.html
+++ b/public/common/templates/_selectedObjects.tmpl.html
@@ -36,7 +36,7 @@
     <tr>
         <td width="50"><img src='${object.thumbnail}' width="50" alt=""/></td>
         <td>${object.title}</td>
-        <td width="90"><input type="radio" name="is_thumb" value="${id}" data-bind='visible: (typeof hubType === "function" ? hubType() == "object" : hubType == "object" ), checked: $item.thumbnail'></td>
+        <td width="90"><input type="radio" name="is_thumb" value="${id}" data-bind='checked: $item.thumbnail'></td>
         <td width="120">
             <a href="#" class="button" data-bind="click: function() { this.removeObject(object) }">
                 <span class="icon icon186"></span>


### PR DESCRIPTION
Use heritage objects as thumbnails for Collections and Stories, and use them in Stories.

After pulling this request in, all UGC content should be converted (or if it's test data, dropped).
