### PR TITLE
Added more functionality to the explain field mechanism. Also added the ...

### DIFF
--- a/conf/legacy-view-definition.xml
+++ b/conf/legacy-view-definition.xml
@@ -5,6 +5,7 @@
         <elem name="result">
             <attrs>
                 <attr prefix="xmlns" name="delving" value="http://www.delving.eu/schemas/"/>
+                <attr prefix="xmlns" name="custom" value="http://www.delving.eu/schemas/"/>
                 <attr prefix="xmlns" name="dc" value="http://purl.org/dc/elements/1.1/"/>
                 <attr prefix="xmlns" name="dcterms" value="http://purl.org/dc/termes/"/>
                 <attr prefix="xmlns" name="europeana" value="http://www.europeana.eu/schemas/ese/"/>

--- a/core/app/core/search/SolrServer.scala
+++ b/core/app/core/search/SolrServer.scala
@@ -141,12 +141,12 @@ object SolrServer {
 
   }
 
-  def getFacetFieldAutocomplete(facetName: String,  facetQuery: String) = {
+  def getFacetFieldAutocomplete(facetName: String,  facetQuery: String, facetLimit: Int = 10) = {
     val normalisedFacetName = "%s_lowercase".format(SolrBindingService.stripDynamicFieldLabels(facetName))
     val normalisedFacetQuery = if (normalisedFacetName.endsWith("_lowercase")) facetQuery.toLowerCase else facetQuery
     val query = new SolrQuery("*:*")
     query setFacet true
-    query setFacetLimit 50
+    query setFacetLimit facetLimit
     query setFacetMinCount 1
 //    query addFacetField (normalisedFacetName)
 //    query setFacetPrefix (normalisedFacetName, normalisedFacetQuery)
@@ -157,7 +157,7 @@ object SolrServer {
     val facetValues = (response getFacetField (facetName))
 //    val facetValuesLowerCase = (response getFacetField (normalisedFacetName))
 
-    if (facetValues.getValueCount != 0) facetValues.getValues.asScala.take(10) else List[FacetField.Count]()
+    if (facetValues.getValueCount != 0) facetValues.getValues.asScala else List[FacetField.Count]()
   }
 
 }


### PR DESCRIPTION
...custom namespace to the rendering layout of the legacy format.

With this fix in the search API a request like this

`search?explain=fieldValue&field=delving_creator_facet&value=&format=json&rows=50` 

will give back the normal autocomplete, but 

`search?explain=fieldValue&field=listAll`

will give back a list of all fields that can be used for the autocomplete.
