### PR TITLE
Search api evolution

### DIFF
--- a/core/app/core/rendering/ViewRenderer.scala
+++ b/core/app/core/rendering/ViewRenderer.scala
@@ -223,11 +223,9 @@ class ViewRenderer(schema: String, viewName: String) {
                 val internationalizationKey = "metadata." + current.getNodeName.replaceAll(":", ".")
 
                 val renderNode = RenderNode("field", None)
-                renderNode += RenderNode("key", Some(Messages(internationalizationKey)))
-                renderNode += RenderNode("value", Some(current.getNodeName.replaceAll(":", "_")))
+                renderNode += RenderNode("name", Some(current.getNodeName.replaceAll(":", "_")))
+                renderNode += RenderNode("i18n", Some(Messages(internationalizationKey)))
                 appendNode(renderNode)
-
-
 
 
               // ~~~ html helpers

--- a/core/app/core/search/SearchService.scala
+++ b/core/app/core/search/SearchService.scala
@@ -373,8 +373,8 @@ case class SearchSummary(result: BriefItemView, language: String = "en", chRespo
             {uniqueKeyNames.map {
             item =>
               <field>
-                <key>{SearchService.localiseKey(item, language)}</key>
-                <value>{item}</value>
+                <name>{item}</name>
+                <i18n>{SearchService.localiseKey(item, language)}</i18n>
               </field>
           }}
           </fields>
@@ -440,7 +440,7 @@ case class SearchSummary(result: BriefItemView, language: String = "en", chRespo
               "links" -> pagination.getPageLinks.map(pageLink => ListMap("start" -> pageLink.start, "isLinked" -> pageLink.isLinked, "pageNumber" -> pageLink.display))
             ),
           "layout" ->
-            ListMap[String, Any]("layout" -> uniqueKeyNames.map(item => ListMap("key" -> SearchService.localiseKey(item, language), "value" -> item))),
+            ListMap[String, Any]("layout" -> uniqueKeyNames.map(item => ListMap("name" -> item, "i18n" -> SearchService.localiseKey(item, language)))),
           "items" ->
             result.getBriefDocs.map(doc => createJsonRecord(doc)).toList,
           "facets" -> createFacetList


### PR DESCRIPTION
Instead of returning key, value pairs, where the values are inverted, we now return name and i18n, name being the key and i18n the internationalized value. This is because in JSON, "key" and "value" are reserved keywords and hence the API is not valid.
