### PR TITLE
12.11 solr fixes

### DIFF
--- a/extras/servlet-server/solr/core2/conf/schema.xml
+++ b/extras/servlet-server/solr/core2/conf/schema.xml
@@ -471,7 +471,7 @@
     See http://wiki.apache.org/solr/SpatialSearch
    -->
     <!--<fieldtype name="geohash" class="solr.GeoHashField"/>-->
-    <fieldType name="geohash" class="solr2155.solr.schema.GeoHashField" length="12" />
+    <fieldType name="geohash" class="solr2155.solr.schema.GeoHashField" length="20" />
 
    <!-- Money/currency field type. See http://wiki.apache.org/solr/MoneyFieldType
         Parameters:

--- a/extras/servlet-server/solr/test/conf/schema.xml
+++ b/extras/servlet-server/solr/test/conf/schema.xml
@@ -471,7 +471,7 @@
     See http://wiki.apache.org/solr/SpatialSearch
    -->
     <!--<fieldtype name="geohash" class="solr.GeoHashField"/>-->
-    <fieldType name="geohash" class="solr2155.solr.schema.GeoHashField" length="12" />
+    <fieldType name="geohash" class="solr2155.solr.schema.GeoHashField" length="20" />
 
    <!-- Money/currency field type. See http://wiki.apache.org/solr/MoneyFieldType
         Parameters:
@@ -911,8 +911,11 @@
    <field name="delving_creator" type="text_general" indexed="true" stored="true" multiValued="true"/>
    <field name="delving_visibility" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="delving_thumbnail" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="delving_imageUrl" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="delving_geohash" type="geohash" indexed="true" stored="true" multiValued="true"/>
    <field name="delving_hasDigitalObject" type="boolean" indexed="true" stored="true" multiValued="false"/>
+   <field name="delving_hasGeoHash" type="boolean" indexed="true" stored="true" multiValued="false"/>
+   <field name="delving_address" type="text_general" indexed="true" stored="true" multiValued="true"/>
    <field name="delving_landingPage" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="delving_collection" type="text_general" indexed="true" stored="true" multiValued="true"/>
    <field name="delving_fullText" type="text_general" indexed="true" stored="true" multiValued="true"/>
@@ -1026,6 +1029,7 @@ unknown fields indexed and/or stored by default -->
      <copyField source="delving_visibility" dest="text"/>
      <copyField source="delving_thumbnail" dest="text"/>
      <copyField source="delving_imageUrl" dest="text"/>
+     <copyField source="delving_address" dest="text"/>
      <copyField source="delving_hasDigitalObject" dest="text"/>
      <copyfield source="delving_landingPage" dest="text"/>
      <copyField source="delving_collection" dest="text"/>

--- a/extras/servlet-server/solr/test/conf/solrconfig.xml
+++ b/extras/servlet-server/solr/test/conf/solrconfig.xml
@@ -873,7 +873,7 @@
   </requestHandler>
 
 
-    <requestHandler name="moreLikeThis" class="solr.MoreLikeThisHandler">
+    <requestHandler name="itinMoreLikeThis" class="solr.MoreLikeThisHandler">
         <lst name="defaults">
             <str name="mlt.fl">itin_link_path_s,itin_related_pvb_link,dc_title_text,dc_creator_text,dc_subject_text,drup_bundle_string</str>
             <int name="mlt.mindf">1</int>
@@ -886,6 +886,21 @@
             <str name="mlt.maxwl">20</str>
             <str name="mlt.maxqt">15</str>
             <str name="mlt.qf">itin_link_path_s ^1.1</str>
+        </lst>
+    </requestHandler>
+
+    <requestHandler name="moreLikeThis" class="solr.MoreLikeThisHandler">
+        <lst name="defaults">
+            <str name="mlt.fl">delving_description</str>
+            <int name="mlt.mindf">1</int>
+            <int name="mlt.mintf">1</int>
+            <bool name="mlt.match.include">true</bool>
+            <str name="mlt.interestingTerms">details</str>
+            <bool name="mlt.boost">false</bool>
+            <int name="mlt.minwl">3</int>
+            <int name="mlt.maxwl">20</int>
+            <int name="mlt.maxqt">15</int>
+            <str name="mlt.qf">delving_description ^1.1</str>
         </lst>
     </requestHandler>
 

--- a/web-core/app/core/search/SolrQueryService.scala
+++ b/web-core/app/core/search/SolrQueryService.scala
@@ -258,7 +258,7 @@ object SolrQueryService extends SolrServer {
     val solrQuery = if (idType == DelvingIdType.LEGACY) {
       "%s:\"%s\" delving_orgId:%s".format(t.idSearchField, URLDecoder.decode(t.normalisedId, "utf-8"), configuration.orgId)
     } else if (idType == DelvingIdType.FREE) {
-      "%s delving_orgId:%s".format(t.normalisedId, configuration.orgId)
+      "%s delving_orgId:%s".format(URLDecoder.decode(t.normalisedId, "utf-8"), configuration.orgId)
     } else {
       "%s:\"%s\" delving_orgId:%s".format(t.idSearchField, t.normalisedId, configuration.orgId)
     }
@@ -457,7 +457,7 @@ object DelvingIdType {
   val HUB = DelvingIdType("hubId", HUB_ID.key)
   val INDEX_ITEM = DelvingIdType("indexItem", ID.key)
   val LEGACY = DelvingIdType("legacy", EUROPEANA_URI.key)
-  val FREE = DelvingIdType("free")
+  val FREE = DelvingIdType("free", "")
 
   val types = Seq(SOLR, PMH, DRUPAL, HUB, INDEX_ITEM, LEGACY, FREE)
 

--- a/web-core/app/core/search/SolrQueryService.scala
+++ b/web-core/app/core/search/SolrQueryService.scala
@@ -257,6 +257,8 @@ object SolrQueryService extends SolrServer {
     val t = idType.resolve(id)
     val solrQuery = if (idType == DelvingIdType.LEGACY) {
       "%s:\"%s\" delving_orgId:%s".format(t.idSearchField, URLDecoder.decode(t.normalisedId, "utf-8"), configuration.orgId)
+    } else if (idType == DelvingIdType.FREE) {
+      "%s delving_orgId:%s".format(t.normalisedId, configuration.orgId)
     } else {
       "%s:\"%s\" delving_orgId:%s".format(t.idSearchField, t.normalisedId, configuration.orgId)
     }
@@ -455,8 +457,9 @@ object DelvingIdType {
   val HUB = DelvingIdType("hubId", HUB_ID.key)
   val INDEX_ITEM = DelvingIdType("indexItem", ID.key)
   val LEGACY = DelvingIdType("legacy", EUROPEANA_URI.key)
+  val FREE = DelvingIdType("free")
 
-  val types = Seq(SOLR, PMH, DRUPAL, HUB, INDEX_ITEM, LEGACY)
+  val types = Seq(SOLR, PMH, DRUPAL, HUB, INDEX_ITEM, LEGACY, FREE)
 
   def apply(idType: String): DelvingIdType = types.find(_.idType == idType).getOrElse(DelvingIdType.HUB)
 


### PR DESCRIPTION
This brings some fixes to the solr configuration and add support for custom queries in the id-based api resolver. This allows for flexible resolving of ids - with their related items - even when only their local ids are known  and not the hubId. This functionality is mainly geared towards more flexible id resolving for IndexItems
