### PR TITLE
Configuration-based API key mechanism

### DIFF
--- a/web-core/app/core/search/SearchService.scala
+++ b/web-core/app/core/search/SearchService.scala
@@ -70,12 +70,13 @@ class SearchService(request: RequestHeader, hiddenQueryFilters: Seq[String] = Se
   def getApiResult: PlainResult = {
 
     val response = try {
-      if (configuration.searchService.apiWsKey) {
-        val wskey = params.getValueOrElse("wskey", "unknown") //paramMap.getOrElse("wskey", Array[String]("unknown")).head
-        // todo add proper wskey checking
-        if (!wskey.toString.equalsIgnoreCase("unknown")) {
-          Logger.warn(String.format("Service Access Key %s invalid!", wskey));
-          throw new AccessKeyException(String.format("Access Key %s not accepted", wskey));
+      if (configuration.searchService.apiWsKeyEnabled) {
+        val wsKey = params.getValueOrElse("wskey", "unknown")
+        val wsKeyProvided = !wsKey.equalsIgnoreCase("unknown")
+        if ((configuration.searchService.apiWsKeyEnabled && !wsKeyProvided) ||
+            (configuration.searchService.apiWsKeyEnabled && wsKeyProvided && !configuration.searchService.apiWsKeys.exists(_ == wsKey.trim))) {
+          Logger("CultureHub").warn("[%s] Service Access Key %s invalid!".format(configuration.orgId, wsKey))
+          throw new AccessKeyException(String.format("Access Key %s not accepted", wsKey))
         }
       }
       format match {

--- a/web-core/app/models/DomainConfiguration.scala
+++ b/web-core/app/models/DomainConfiguration.scala
@@ -153,7 +153,8 @@ case class SearchServiceConfiguration(
   sortFields:                   String, // dc_creator,dc_provider:desc
   moreLikeThis:                 MoreLikeThis,
   searchIn:                     Map[String, String],
-  apiWsKey:                     Boolean = false,
+  apiWsKeyEnabled:              Boolean = false,
+  apiWsKeys:                    Seq[String] = Seq.empty,
   pageSize:                     Int,
   showResultsWithoutThumbnails: Boolean = false
 )
@@ -223,7 +224,8 @@ object OrganizationConfiguration {
   val SEARCH_HQF = "services.search.hiddenQueryFilter"
   val SEARCH_FACETS = "services.search.facets"
   val SEARCH_SORTFIELDS = "services.search.sortFields"
-  val SEARCH_APIWSKEY = "services.search.apiWsKey"
+  val SEARCH_APIWSKEYENABLED = "services.search.apiWsKeyEnabled"
+  val SEARCH_APIWSKEYS = "services.search.apiWsKeys"
   val SEARCH_MORELIKETHIS = "services.search.moreLikeThis"
   val SEARCH_SEARCHIN = "services.search.searchIn"
   val SEARCH_PAGE_SIZE = "services.search.pageSize"
@@ -258,7 +260,7 @@ object OrganizationConfiguration {
     COMMONS_HOST, COMMONS_NODE_NAME,
     IMAGE_CACHE_DATABASE, FILESTORE_DATABASE, TILES_WORKING_DIR, TILES_OUTPUT_DIR,
     OAI_REPO_NAME, OAI_ADMIN_EMAIL, OAI_EARLIEST_TIMESTAMP, OAI_REPO_IDENTIFIER, OAI_SAMPLE_IDENTIFIER, OAI_RESPONSE_LIST_SIZE, OAI_ALLOW_RAW_HARVESTING,
-    SEARCH_FACETS, SEARCH_SORTFIELDS, SEARCH_APIWSKEY,
+    SEARCH_FACETS, SEARCH_SORTFIELDS,
     BASEX_HOST, BASEX_PORT, BASEX_EPORT, BASEX_USER, BASEX_PASSWORD,
     PROVIDER_DIRECTORY_URL,
     EMAIL_ADMINTO, EMAIL_EXCEPTIONTO, EMAIL_FEEDBACKTO, EMAIL_REGISTERTO, EMAIL_SYSTEMFROM, EMAIL_FEEDBACKFROM
@@ -343,7 +345,8 @@ object OrganizationConfiguration {
                   hiddenQueryFilter = getOptionalString(configuration, SEARCH_HQF).getOrElse(""),
                   facets = getString(configuration, SEARCH_FACETS),
                   sortFields = getString(configuration, SEARCH_SORTFIELDS),
-                  apiWsKey = getBoolean(configuration, SEARCH_APIWSKEY),
+                  apiWsKeyEnabled = getOptionalBoolean(configuration, SEARCH_APIWSKEYENABLED).getOrElse(false),
+                  apiWsKeys = getOptionalStringList(configuration, SEARCH_APIWSKEYS).getOrElse(Seq.empty),
                   moreLikeThis = {
                     val mlt = configuration.getConfig(SEARCH_MORELIKETHIS)
                     val default = MoreLikeThis()
@@ -598,6 +601,13 @@ object OrganizationConfiguration {
 
   private def getOptionalString(configuration: Configuration, key: String): Option[String] =
     configuration.getString(key).orElse(Play.configuration.getString(key))
+
+  private def getOptionalStringList(configuration: Configuration, key: String): Option[Seq[String]] =
+    if (configuration.underlying.hasPath(key))
+      Some(configuration.underlying.getStringList(key).asScala.toSeq)
+   else
+      None
+
 
   private def getInt(configuration: Configuration, key: String): Int =
     configuration.getInt(key).getOrElse(Play.configuration.getInt(key).get)


### PR DESCRIPTION
In order to use this, the following configuration parameters are required in the "search" section of the services configuration:

```
apiWsKeyEnabled = true,
apiWsKeys = [ "abc", "def" ]
```
