### PR TITLE
13.03 Read Only

### DIFF
--- a/app/views/organization/Admin/index.html
+++ b/app/views/organization/Admin/index.html
@@ -10,7 +10,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"administration", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"administration", navigation: navigation /}
 
 <div class="org-admin row">
 

--- a/app/views/organization/Groups/groups.html
+++ b/app/views/organization/Groups/groups.html
@@ -7,7 +7,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"groups", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"groups", navigation: navigation /}
 
 <h3>&{'org.group.create'}</h3>
 <form action="" id="groupForm" class="form-delving">

--- a/app/views/organization/Groups/list.html
+++ b/app/views/organization/Groups/list.html
@@ -6,7 +6,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"groups", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"groups", navigation: navigation /}
 
 <div class="row">
     <div class="groups-list span12">

--- a/app/views/organization/Organizations/index.html
+++ b/app/views/organization/Organizations/index.html
@@ -5,7 +5,7 @@
 #{breadcrumbs crumbs: breadcrumbs /}
 
 #{if isMember}
-    #{organizationNavBar orgId: orgId, active: 'overview', navigation: navigation /}
+    #{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: 'overview', navigation: navigation /}
 #{/if}
 
 

--- a/app/views/tags/organizationNavBar.html
+++ b/app/views/tags/organizationNavBar.html
@@ -1,5 +1,16 @@
 <div class="organization-navbar">
     <h2>${_orgId}</h2>
+    #{if _isAdmin && _isReadOnly}
+    <div class="alert alert-block">
+        <p>
+            <strong>Warning!</strong>
+            The system is currently in read-only mode, and as a result a number of actions cannot be performed.
+        </p>
+        <p>
+            We are doing our best to fix the issue.
+        </p>
+    </div>
+    #{/if}
     <ul class="nav nav-tabs">
     #{list _navigation, as: 'mainMenuEntry'}
         #{if mainMenuEntry.mainEntry}

--- a/modules/cms/app/views/cms/CMS/organization/CMS/list.html
+++ b/modules/cms/app/views/cms/CMS/organization/CMS/list.html
@@ -6,7 +6,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active: menuKey, navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: menuKey, navigation: navigation /}
 
 <div class="row">
     <div class="span12">

--- a/modules/cms/app/views/cms/CMS/organization/CMS/page.html
+++ b/modules/cms/app/views/cms/CMS/organization/CMS/page.html
@@ -11,7 +11,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active: menuKey, navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: menuKey, navigation: navigation /}
 
 <div class="accordion" id="instructions">
     <div class="accordion-group">

--- a/modules/cms/app/views/cms/CMS/organization/CMS/upload.html
+++ b/modules/cms/app/views/cms/CMS/organization/CMS/upload.html
@@ -30,7 +30,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"site", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"site", navigation: navigation /}
 <div class="accordion" id="instructions">
     <div class="accordion-group">
         <div class="accordion-heading  clearfix">

--- a/modules/cms/app/views/cms/organization/CMS/list.html
+++ b/modules/cms/app/views/cms/organization/CMS/list.html
@@ -6,7 +6,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active: menuKey, navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: menuKey, navigation: navigation /}
 
 <div class="row">
     <div class="span12">

--- a/modules/cms/app/views/cms/organization/CMS/page.html
+++ b/modules/cms/app/views/cms/organization/CMS/page.html
@@ -11,7 +11,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active: menuKey, navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: menuKey, navigation: navigation /}
 
 <div class="accordion" id="instructions">
     <div class="accordion-group">

--- a/modules/cms/app/views/cms/organization/CMS/upload.html
+++ b/modules/cms/app/views/cms/organization/CMS/upload.html
@@ -30,7 +30,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"site", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"site", navigation: navigation /}
 <div class="accordion" id="instructions">
     <div class="accordion-group">
         <div class="accordion-heading  clearfix">

--- a/modules/dataset/app/controllers/organization/DataSetEventFeed.scala
+++ b/modules/dataset/app/controllers/organization/DataSetEventFeed.scala
@@ -286,9 +286,11 @@ class DataSetEventFeed extends Actor {
               DataSet.dao.findBySpecAndOrgId(spec, orgId).map {
                 set =>
                   {
-                    if (checkAccess(set, userName)) {
+                    if (configuration.isReadOnly) {
+                      send(s, error("The system is in read-only mode and cannot process your request."))
+                    } else if (!configuration.isReadOnly && checkAccess(set, userName)) {
                       block(set)
-                    } else {
+                    } else if (!configuration.isReadOnly) {
                       send(s, error("Sorry, you are not authorized to perform this action!"))
                     }
                   }
@@ -438,7 +440,7 @@ class DataSetEventFeed extends Actor {
                             |
                             |Yours truthfully,
                             |
-                            |The CultureHub robot
+                            |The CultureBot
                           """.stripMargin).send()
                       }
                     }

--- a/modules/dataset/app/controllers/organization/DataSetEventFeed.scala
+++ b/modules/dataset/app/controllers/organization/DataSetEventFeed.scala
@@ -73,9 +73,7 @@ object DataSetEventFeed {
 
   implicit def dataSetListToViewModelList(dsl: Seq[DataSet]): Seq[DataSetViewModel] = dsl.map(dataSetToViewModel(_))
 
-  lazy val default = {
-    Akka.system.actorOf(Props[DataSetEventFeed])
-  }
+  def default = Akka.system.actorFor("akka://application/user/plugin-dataSet/dataSetEventFeed")
 
   def subscribe(orgId: String, clientId: String, userName: String, configuration: String, spec: Option[String]): Future[(Iteratee[JsValue, _], Enumerator[JsValue])] = {
 

--- a/modules/dataset/app/plugins/DatasetPlugin.scala
+++ b/modules/dataset/app/plugins/DatasetPlugin.scala
@@ -25,6 +25,7 @@ import core.access.{ ResourceType, Resource, ResourceLookup }
 import com.mongodb.casbah.commons.MongoDBObject
 import java.util.regex.Pattern
 import java.io.FileInputStream
+import controllers.organization.DataSetEventFeed
 
 class DataSetPlugin(app: Application) extends CultureHubPlugin(app) {
 
@@ -227,6 +228,9 @@ class DataSetPlugin(app: Application) extends CultureHubPlugin(app) {
 
     // DataSet event log housekeeping
     context.actorOf(Props[DataSetEventHousekeeper])
+
+    // DataSet event feed
+    context.actorOf(Props[DataSetEventFeed], name = "dataSetEventFeed")
 
     // only for testing
     testDataProcessor = context.actorOf(Props[DataSetCollectionProcessor])

--- a/modules/dataset/app/views/organization/DataSetControl/dataSet.html
+++ b/modules/dataset/app/views/organization/DataSetControl/dataSet.html
@@ -57,7 +57,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"datasets", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"datasets", navigation: navigation /}
 
 <div class="page-header">
     <h2>${spec.isEmpty() ? messages.get('organization.dataset.create') : messages.get('organization.dataset.update') }</h2>

--- a/modules/dataset/app/views/organization/DataSets/dataSet.html
+++ b/modules/dataset/app/views/organization/DataSets/dataSet.html
@@ -11,7 +11,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active: "datasets", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: "datasets", navigation: navigation /}
 
 <div class="row">
     <div class="dataset-sidebar span5">
@@ -258,19 +258,6 @@
                     payload: '${spec}'
                 }));
             },
-            unlockOrig: function(spec) {
-                bootbox.confirm(msgUnlock, function(result){
-                    if(result){
-                        ws.send(JSON.stringify({
-                            eventType: 'unlockSet',
-                            clientId: clientId,
-                            payload: '${spec}'
-                        }));
-
-                    }
-                });
-
-            },
             unlock: function(spec) {
                 bootbox.dialog(msgUnlock, [{
                     "label"     :   "I am aware of this. Unlock anyway!",
@@ -282,7 +269,6 @@
                             payload: '${spec}'
                             }));
                             var html = '<div class="alert alert-block"><a class="close" data-dismiss="alert" href="#">x</a>' +
-//                                '<strong>Attention!</strong>' +
                                 '<p>Dataset is now unlocked!</p>' +
                                 '</div>'
                         $('#extra-alert').html(html);

--- a/modules/dataset/app/views/organization/DataSets/list.html
+++ b/modules/dataset/app/views/organization/DataSets/list.html
@@ -13,7 +13,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"datasets", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"datasets", navigation: navigation /}
 
 <div class="dataset-filter row">
     <div class="dataset-filter-inner span12">

--- a/modules/dataset/app/views/organization/SipCreator/index.html
+++ b/modules/dataset/app/views/organization/SipCreator/index.html
@@ -4,7 +4,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"sipcreator", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"sipcreator", navigation: navigation /}
 
 <h3>SIP-Creator</h3>
 

--- a/modules/hubNode/app/views/organization/HubNodes/hubNode.html
+++ b/modules/hubNode/app/views/organization/HubNodes/hubNode.html
@@ -6,7 +6,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"hubNode", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"hubNode", navigation: navigation /}
 
 
 <div class="row">

--- a/modules/hubNode/app/views/organization/HubNodes/list.html
+++ b/modules/hubNode/app/views/organization/HubNodes/list.html
@@ -6,7 +6,7 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"hubNode", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"hubNode", navigation: navigation /}
 
 <div class="row">
     <div class="span12">

--- a/modules/statistics/app/views/statistics.html
+++ b/modules/statistics/app/views/statistics.html
@@ -5,6 +5,6 @@
 
 #{breadcrumbs crumbs: breadcrumbs /}
 
-#{organizationNavBar orgId: orgId, active:"statistics", navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active:"statistics", navigation: navigation /}
 
 #{statisticsTable orgId: orgId /}

--- a/web-core/app/controllers/DelvingController.scala
+++ b/web-core/app/controllers/DelvingController.scala
@@ -221,6 +221,8 @@ trait DelvingController extends ApplicationController {
             val isAdmin = organizationServiceLocator.byDomain.isAdmin(configuration.orgId, userName)
             renderArgs += ("isAdmin" -> isAdmin.asInstanceOf[AnyRef])
 
+            renderArgs += ("isReadOnly" -> configuration.isReadOnly.asInstanceOf[AnyRef])
+
             // Connected user
             HubUser.dao.findByUsername(userName).foreach { u =>
               renderArgs += ("fullName" -> u.fullname)

--- a/web-core/app/core/search/SolrServer.scala
+++ b/web-core/app/core/search/SolrServer.scala
@@ -46,7 +46,13 @@ trait SolrServer {
 
   def getSolrServer(configuration: OrganizationConfiguration) = SolrServer.solrServer(configuration)
 
-  def getStreamingUpdateServer(configuration: OrganizationConfiguration) = SolrServer.streamingUpdateServer(configuration)
+  def getStreamingUpdateServer(configuration: OrganizationConfiguration) = {
+    if (!configuration.isReadOnly) {
+      SolrServer.streamingUpdateServer(configuration)
+    } else {
+      throw new RuntimeException("System is in read-only mode, no indexing is possible at the moment")
+    }
+  }
 
   def runQuery(query: SolrQuery, retries: Int = 0)(implicit configuration: OrganizationConfiguration): QueryResponse = {
     try {

--- a/web-core/app/models/OrganizationConfiguration.scala
+++ b/web-core/app/models/OrganizationConfiguration.scala
@@ -22,6 +22,7 @@ package models {
       orgId: String,
       domains: List[String] = List.empty,
       instances: List[String] = List.empty,
+      isReadOnly: Boolean = false,
 
       // ~~~ mail
       emailTarget: EmailTarget = EmailTarget(),
@@ -200,6 +201,7 @@ package models {
     val ORG_ID = "orgId"
 
     val INSTANCES = "instances"
+    val READ_ONLY = "readOnly"
 
     val SOLR_BASE_URL = "solr.baseUrl"
     val SOLR_INDEXER_URL = "solr.indexerUrl"
@@ -432,6 +434,7 @@ package models {
       orgId = configuration.getString(ORG_ID).get,
       domains = configuration.underlying.getStringList("domains").asScala.toList,
       instances = configuration.underlying.getStringList(INSTANCES).asScala.toList,
+      isReadOnly = configuration.getBoolean(READ_ONLY).getOrElse(false),
       mongoDatabase = configuration.getString(MONGO_DATABASE).get,
       baseXConfiguration = BaseXConfiguration(
         host = getString(configuration, BASEX_HOST),

--- a/web-core/app/views/organization/crudHeader.html
+++ b/web-core/app/views/organization/crudHeader.html
@@ -3,6 +3,6 @@
 #{set title: messages.get(titleKey) /}
 #{set bodyId: 'organization' /}
 #{breadcrumbs crumbs: breadcrumbs /}
-#{organizationNavBar orgId: orgId, active: menuKey, navigation: navigation /}
+#{organizationNavBar isReadOnly: isReadOnly, isAdmin: isAdmin, orgId: orgId, active: menuKey, navigation: navigation /}
 
 #{doLayout /}


### PR DESCRIPTION
The Hub can be set to be "read-only", i.e. no data-writing operations are possible. This is useful for a failover set-up that doesn't have master-to-master replication on all systems, such as SOLR.
