### PR TITLE
The downloaded source file should be re-used if the hash hasn't changed

### DIFF
--- a/modules/dataset/app/controllers/SipCreatorEndPoint.scala
+++ b/modules/dataset/app/controllers/SipCreatorEndPoint.scala
@@ -4,7 +4,7 @@ import exceptions.{ StorageInsertionException, AccessKeyException }
 import play.api.mvc._
 import java.util.zip.{ ZipEntry, ZipOutputStream, GZIPInputStream }
 import java.io._
-import org.apache.commons.io.IOUtils
+import org.apache.commons.io.{ FileUtils, IOUtils }
 import play.api.libs.iteratee.Enumerator
 import play.libs.Akka
 import akka.actor.Actor
@@ -499,6 +499,77 @@ trait SipCreatorEndPoint extends Controller with OrganizationConfigurationAware 
 
     val recordCount = basexStorage.count(dataSet)
 
+    if (recordCount > 0) {
+      writeEntry("source.xml", zipOut) {
+        out => writeDataSetSource(dataSet, out)
+      }
+    }
+
+    for (mapping <- dataSet.mappings) {
+      if (mapping._2.recordMapping != None) {
+        writeEntry("mapping_%s.xml".format(mapping._1), zipOut) {
+          out => writeContent(mapping._2.recordMapping.get, out)
+        }
+      }
+    }
+
+    zipOut.close()
+    fos.close()
+    temp.file
+  }
+
+  /**
+   * Writes the contents of the DataSet, i.e. the data, to the output stream.
+   * Rather than going to BaseX each time, we cache the result of the serialization
+   * @param dataSet the DataSet for which to write the source data
+   * @param out the outputStream
+   */
+  private def writeDataSetSource(dataSet: DataSet, out: OutputStream)(implicit configuration: OrganizationConfiguration) {
+    // is there an already prepared version cached on disk?
+    // assume we have a hash
+    dataSet.hashes.get("source--xml--gz").map { hash =>
+      val prepared = new File(System.getProperty("java.io.tmpdir"), s"/source_${dataSet.orgId}_${dataSet.spec}_$hash.xml")
+      if (prepared.exists()) {
+        log.info(s"DataSet source ${dataSet.spec} has been cached, writing it directly from ${prepared.getAbsolutePath}")
+        IOUtils.copy(new FileInputStream(prepared), out)
+      } else {
+        log.info(s"DataSet source ${dataSet.spec} has not yet been cached, preparing it")
+
+        try {
+          // remove any prior version of a cached stream for this set
+          val tmpDir = new File(System.getProperty("java.io.tmpdir"))
+          tmpDir.listFiles().find(f => f.getName.startsWith(s"source_${dataSet.orgId}_${dataSet.spec}")) foreach { f =>
+            FileUtils.deleteQuietly(f)
+          }
+        } catch {
+          case t: Throwable =>
+            log.error("Could not remove prior version of prepared DataSet file", t)
+        }
+
+        prepared.createNewFile()
+        val fOut = new FileOutputStream(prepared)
+        try {
+          prepareDataSetSource(dataSet, fOut)
+          IOUtils.copy(new FileInputStream(prepared), out)
+        } catch {
+          case t: Throwable =>
+            log.error("Cannot prepare DataSet source file", t)
+        } finally {
+          fOut.close()
+        }
+      }
+    }.getOrElse {
+      log.error("Cannot prepare DataSet source file: no hash found")
+    }
+  }
+
+  private def prepareDataSetSource(dataSet: DataSet, out: OutputStream)(implicit configuration: OrganizationConfiguration) {
+
+    val now = System.currentTimeMillis()
+
+    val tagContentMatcher = """>([^<]+)<""".r
+    val inputTagMatcher = """<input (.*) id="(.*)">""".r
+
     def buildNamespaces(attrs: Map[String, String]): String = {
       val attrBuilder = new StringBuilder
       attrs.filterNot(_._1.isEmpty).toSeq.sortBy(_._1).foreach(
@@ -545,76 +616,56 @@ trait SipCreatorEndPoint extends Controller with OrganizationConfigurationAware 
         replaceAll("'", "&apos;")
     }
 
-    val tagContentMatcher = """>([^<]+)<""".r
-    val inputTagMatcher = """<input (.*) id="(.*)">""".r
+    val pw = new PrintWriter(new OutputStreamWriter(out, "utf-8"))
+    val builder = new StringBuilder
+    builder.append("<?xml version='1.0' encoding='UTF-8'?>").append("\n")
+    builder.append("<delving-sip-source ")
+    builder.append("%s".format(buildNamespaces(dataSet.getNamespaces)))
+    builder.append(">")
+    write(builder.toString(), pw, out)
 
-    if (recordCount > 0) {
-      writeEntry("source.xml", zipOut) {
-        out =>
-          val pw = new PrintWriter(new OutputStreamWriter(out, "utf-8"))
-          val builder = new StringBuilder
-          builder.append("<?xml version='1.0' encoding='UTF-8'?>").append("\n")
-          builder.append("<delving-sip-source ")
-          builder.append("%s".format(buildNamespaces(dataSet.getNamespaces)))
-          builder.append(">")
-          write(builder.toString(), pw, out)
+    basexStorage.withSession(dataSet) {
+      implicit session =>
+        val total = basexStorage.count
+        var count = 0
+        basexStorage.findAllCurrentDocuments foreach {
+          record =>
 
-          basexStorage.withSession(dataSet) {
-            implicit session =>
-              val total = basexStorage.count
-              var count = 0
-              basexStorage.findAllCurrentDocuments foreach {
-                record =>
+            // the output coming from BaseX differs from the original source as follows:
+            // - the <input> tags contain the namespace declarations
+            // - the formatted XML escapes all entities including UTF-8 characters
+            // the following lines fix this
+            val noNamespaces = inputTagMatcher.replaceSomeIn(record, {
+              m => Some("""<input id="%s">""".format(m.group(2)))
+            })
 
-                  // the output coming from BaseX differs from the original source as follows:
-                  // - the <input> tags contain the namespace declarations
-                  // - the formatted XML escapes all entities including UTF-8 characters
-                  // the following lines fix this
-                  val noNamespaces = inputTagMatcher.replaceSomeIn(record, {
-                    m => Some("""<input id="%s">""".format(m.group(2)))
-                  })
+            def cleanup: Match => String = {
+              s => ">" + escapeXml(StringEscapeUtils.unescapeXml(s.group(1))) + "<"
+            }
 
-                  def cleanup: Match => String = {
-                    s => ">" + escapeXml(StringEscapeUtils.unescapeXml(s.group(1))) + "<"
-                  }
+            val escapeForRegex = Matcher.quoteReplacement(noNamespaces)
+            try {
+              val cleaned = tagContentMatcher.replaceAllIn(escapeForRegex, cleanup)
+              pw.println(cleaned)
+            } catch {
+              case t: Throwable =>
+                log.error(
+                  "Error while trying to sanitize following record:\n\n" + escapeForRegex
+                )
+                throw t
+            }
 
-                  val escapeForRegex = Matcher.quoteReplacement(noNamespaces)
-                  try {
-                    val cleaned = tagContentMatcher.replaceAllIn(escapeForRegex, cleanup)
-                    pw.println(cleaned)
-                  } catch {
-                    case t: Throwable =>
-                      log.error(
-                        "Error while trying to sanitize following record:\n\n" + escapeForRegex
-                      )
-                      throw t
-                  }
-
-                  if (count % 10000 == 0) pw.flush()
-                  if (count % 10000 == 0) {
-                    log.info("%s: Prepared %s of %s records for download".format(dataSet
-                      .spec, count, total))
-                  }
-                  count += 1
-              }
-              pw.print("</delving-sip-source>")
-              log.info("Done preparing DataSet %s for download".format(dataSet.spec))
-              pw.flush()
-          }
-      }
-    }
-
-    for (mapping <- dataSet.mappings) {
-      if (mapping._2.recordMapping != None) {
-        writeEntry("mapping_%s.xml".format(mapping._1), zipOut) {
-          out => writeContent(mapping._2.recordMapping.get, out)
+            if (count % 10000 == 0) pw.flush()
+            if (count % 10000 == 0) {
+              log.info("%s: Prepared %s of %s records for download".format(dataSet
+                .spec, count, total))
+            }
+            count += 1
         }
-      }
+        pw.print("</delving-sip-source>")
+        log.info(s"Done preparing DataSet ${dataSet.spec} for download, it took ${System.currentTimeMillis() - now} ms")
+        pw.flush()
     }
-
-    zipOut.close()
-    fos.close()
-    temp.file
   }
 
   private def writeEntry(name: String, out: ZipOutputStream)(f: ZipOutputStream => Unit) {

--- a/modules/mediator/test/MediatorServerSpec.scala
+++ b/modules/mediator/test/MediatorServerSpec.scala
@@ -15,14 +15,14 @@ class MediatorServerSpec extends Specs2TestContext {
 
     "return 404 if an image was not found" in {
       withTestConfig { implicit configuration: OrganizationConfiguration =>
-        val result = MediatorServer.newFile("delving", "fooSet", "fooFile.jpg", s"http://${configuration.domains.head}:9000/media/fault/newFile")(FakeRequest())
+        val result = MediatorServer.newFile("delving", "fooSet", "fooFile.jpg", "bob", s"http://${configuration.domains.head}:9000/media/fault/newFile")(FakeRequest())
         status(result) must equalTo(404)
       }
     }
     "return 400 if a file is not an image" in {
       val here = (new File("modules/mediator"))
       withTestConfig(Map("configurations.delving.plugin.mediator.sourceDirectory" -> here.getAbsolutePath)) { implicit configuration: OrganizationConfiguration =>
-        val result = MediatorServer.newFile("delving", "conf", "mediator.routes", s"http://${configuration.domains.head}:9000/media/fault/newFile")(FakeRequest())
+        val result = MediatorServer.newFile("delving", "conf", "mediator.routes", "bob", s"http://${configuration.domains.head}:9000/media/fault/newFile")(FakeRequest())
         status(result) must equalTo(400)
       }
     }


### PR DESCRIPTION
When the Sip-Creator requests a sip.zip file for download, the hub needs to build the source XML anew form basex and carefully re-construct it the exact same way that it was sent in, because otherwise the hash is different when it gets back on the client.

This process can take a long time, especially for large sets. Instead of repeating the operation at every time, we should look into caching the result of this operation (source data serialization) and re-use it if the hash has not changed.
