### PR TITLE
dataset administration connection fail modal

### DIFF
--- a/modules/dataset/app/views/organization/DataSets/dataSet.html
+++ b/modules/dataset/app/views/organization/DataSets/dataSet.html
@@ -219,9 +219,10 @@
 <script type="text/javascript" language="javascript">
     $(document).ready(function () {
 
-        var clientId = Math.floor(1 + 10001 * Math.random());
-        var ws = new WebSocket("ws://" + location.host + "/organizations/${orgId}/dataset/feed?clientId=" + clientId + '&spec=${spec}');
+        var clientId;
+
         var msgUnlock = "When a dataset is locked, the locking user is considered to be in full control.  Unlocking implies taking that control away, which should not be done without the permission of the locking user because it invalidates their current work on the dataset.";
+
         var viewModel = {
 
             progressPercentage: ko.observable('0%'),
@@ -308,7 +309,7 @@
             }
         };
 
-        ws.onopen = function() {
+        var onopen = function() {
             ws.send(JSON.stringify({
                 eventType: "sendSet",
                 clientId: clientId,
@@ -316,13 +317,7 @@
             }));
         };
 
-        var retries = 0;
-
-        ws.onclose = function() {
-            bootbox.alert("Lost connection with the server. Please refresh the page.");
-        };
-
-        ws.onmessage = function(evt) {
+        var onmessage = function(evt) {
             var data = $.parseJSON(evt.data);
             console.log(data)
             switch(data.eventType) {
@@ -367,6 +362,8 @@
                     break;
             }
         };
+
+        clientId = feed('${orgId}', '${spec}', onopen, onmessage, 0);
 
     });
 

--- a/modules/dataset/app/views/organization/DataSets/list.html
+++ b/modules/dataset/app/views/organization/DataSets/list.html
@@ -101,6 +101,8 @@
 <script type="text/javascript" language="javascript">
     $(document).ready(function () {
 
+        var clientId;
+
         var viewModel = {
             sets: ko.observableArray(),
             stateToClass: function(state) { return stateToClass(state) },
@@ -120,17 +122,14 @@
             }
         };
 
-        var clientId = Math.floor(1 + 10001 * Math.random());
-        var ws = new WebSocket("ws://" + location.host + "/organizations/${orgId}/dataset/feed?clientId=" + clientId);
-
-        ws.onopen = function() {
+        var onopen = function() {
             ws.send(JSON.stringify({
                 eventType: "sendList",
                 clientId: clientId
             }));
         };
 
-        ws.onmessage = function(evt) {
+        var onmessage = function(evt) {
             var data = $.parseJSON(evt.data);
             switch(data.eventType) {
                 case "loadList":
@@ -189,6 +188,8 @@
                     break;
             }
         };
+
+        clientId = feed('${orgId}', '${spec}', onopen, onmessage, 0);
 
         ko.applyBindings(viewModel);
 

--- a/modules/dataset/app/views/organization/DataSets/list.html
+++ b/modules/dataset/app/views/organization/DataSets/list.html
@@ -26,6 +26,13 @@
     </div>
 </div>
 
+<div class="alert alert-error hide" id="ws-connection-alert">
+    <button type="button" class="close" data-dismiss="alert">&times;</button>
+    <h4>Server connection lost</h4>
+    <p>Lost connection with the server. Please refresh the page.</p>
+    <p></p><button class="btn" id="ws-reconnect">Refresh the page now</button></p>
+</div>
+
 <div class="dataset-list row">
     <div class="dataset-list-inner span12">
     <table id="dataset-table" class="table table-striped sortable" data-bind="triggerUpdate: sets">

--- a/public/common/javascripts/organizations/datasets.js
+++ b/public/common/javascripts/organizations/datasets.js
@@ -52,10 +52,18 @@ function feed(orgId, spec, onopen, onmessage, connectionRetries) {
             setTimeout(function() { feed(orgId, spec, onopen, onmessage, localRetries + 1) }, 5000);
         } else {
             // TODO here we might want to retry, but with a bigger timeout
-            // also instead of a bootbox alert, show a banner
-            bootbox.alert("Lost connection with the server. Please refresh the page.");
+            // show connection warning
+            $('div#ws-connection-alert').show();
+            // sroll to top in case use is working below the page-view line and will not see the warning
+            window.scrollTo(0,0);
 
         }
     };
     return clientId;
 }
+
+jQuery(document).ready(function() {
+    $("button#ws-reconnect").on('click', function(){
+        location.reload();
+    });
+});

--- a/public/common/javascripts/organizations/datasets.js
+++ b/public/common/javascripts/organizations/datasets.js
@@ -31,3 +31,31 @@ function stateToClass(state) {
     }
     return stateClass;
 }
+
+/**
+ * Handles WebSocket connection to DataSet feed
+ * @returns {number} the clientId of the connection, necessary for communicating with the server
+ */
+function feed(orgId, spec, onopen, onmessage, connectionRetries) {
+    var localRetries = connectionRetries;
+    var clientId = Math.floor(1 + 10001 * Math.random());
+    var url = "ws://" + location.host + "/organizations/" + orgId + "/dataset/feed?clientId=" + clientId + '&spec=' + spec;
+    ws = new WebSocket(url);
+    ws.onopen = function() {
+        localRetries = 0;
+        onopen();
+    };
+    ws.onmessage = onmessage;
+    ws.onclose = function() {
+        if (connectionRetries < 3) {
+            console.log("WebSocket disconnected, attempting to reconnect, attempt " + connectionRetries);
+            setTimeout(function() { feed(orgId, spec, onopen, onmessage, localRetries + 1) }, 5000);
+        } else {
+            // TODO here we might want to retry, but with a bigger timeout
+            // also instead of a bootbox alert, show a banner
+            bootbox.alert("Lost connection with the server. Please refresh the page.");
+
+        }
+    };
+    return clientId;
+}


### PR DESCRIPTION
The modal that currently pops-up when the connection to the server is lost is confusing to the user. Replace the modal with a warning bar at the top of the page with a clickable region to refresh the page
