### PR TITLE
Create a now json format that (for example jsonm): minifies the output (strip extra whitespace and hard returns) and gzips it.

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -8,13 +8,14 @@ import core.CultureHubPlugin
 import play.api.libs.concurrent._
 import akka.actor._
 import play.api._
-import mvc.{ Handler, RequestHeader }
+import play.api.mvc.{ WithFilters, Handler, RequestHeader }
 import play.api.Play.current
+import play.extras.iteratees.GzipFilter
 import util.OrganizationConfigurationHandler
 import eu.delving.culturehub.BuildInfo
 import play.api.mvc.Results._
 
-object Global extends GlobalSettings {
+object Global extends WithFilters(new GzipFilter()) {
 
   override def onStart(app: Application) {
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -34,7 +34,8 @@ object Build extends sbt.Build {
 
   val appDependencies = Seq(
     "org.apache.amber"          %  "amber-oauth2-authzserver"        % "0.22-incubating",
-    "org.apache.amber"          %  "amber-oauth2-client"             % "0.22-incubating"
+    "org.apache.amber"          %  "amber-oauth2-client"             % "0.22-incubating",
+    "com.typesafe.play.extras"  %% "iteratees-extras"                % "1.0.1"
   )
 
 


### PR DESCRIPTION
The current output of JSON API is rather fat in size. It averages ca 100 kb per request.

So it would be good if we either create a new json format like 'jsonm' or add another parameter that signifies that that the output should be compressed to reduce the file size.

So options are:
- strip surplus whitespace
- strip hard returns
- or, just gzip the output when you give it back to the browser.
